### PR TITLE
Measure upload

### DIFF
--- a/__tests__/components/MeasureUpload.test.tsx
+++ b/__tests__/components/MeasureUpload.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { mantineRecoilWrap, getMockRecoilState } from '../helpers/testHelpers';
+import { measureBundleState } from '../../state/atoms/measureBundle';
+import MeasureUpload from '../../components/MeasureUpload';
+
+describe('MeasureUpload', () => {
+  it('renders a dropzone with generic label when no measure uploaded', () => {
+    render(mantineRecoilWrap(<MeasureUpload />));
+
+    const dropzone = screen.getByRole('button');
+    expect(dropzone).toBeInTheDocument();
+    const title = screen.getByText('Drag a Measure Bundle JSON file here or click to select files');
+    expect(title).toBeInTheDocument();
+  });
+  it('renders a dropzone with measure bundle name label when measure uploaded', () => {
+    const MockMB = getMockRecoilState(measureBundleState, { name: 'testName' });
+    render(
+      mantineRecoilWrap(
+        <>
+          <MockMB />
+          <MeasureUpload />
+        </>
+      )
+    );
+
+    const dropzone = screen.getByRole('button');
+    expect(dropzone).toBeInTheDocument();
+    const title = screen.getByText('testName');
+    expect(title).toBeInTheDocument();
+  });
+  // TODO: Consider testing for recoil state changes once file upload fire events are figured out
+});

--- a/__tests__/components/MeasureUpload.test.tsx
+++ b/__tests__/components/MeasureUpload.test.tsx
@@ -14,7 +14,10 @@ describe('MeasureUpload', () => {
     expect(title).toBeInTheDocument();
   });
   it('renders a dropzone with measure bundle name label when measure uploaded', () => {
-    const MockMB = getMockRecoilState(measureBundleState, new File([], 'testName'));
+    const MockMB = getMockRecoilState(measureBundleState, {
+      name: 'testName',
+      content: { resourceType: 'Bundle', type: 'transaction' }
+    });
     render(
       mantineRecoilWrap(
         <>

--- a/__tests__/components/MeasureUpload.test.tsx
+++ b/__tests__/components/MeasureUpload.test.tsx
@@ -14,7 +14,7 @@ describe('MeasureUpload', () => {
     expect(title).toBeInTheDocument();
   });
   it('renders a dropzone with measure bundle name label when measure uploaded', () => {
-    const MockMB = getMockRecoilState(measureBundleState, { name: 'testName' });
+    const MockMB = getMockRecoilState(measureBundleState, new File([], 'testName'));
     render(
       mantineRecoilWrap(
         <>

--- a/__tests__/helpers/testHelpers.tsx
+++ b/__tests__/helpers/testHelpers.tsx
@@ -1,6 +1,7 @@
 import { ColorSchemeProvider, MantineProvider } from '@mantine/core';
 import { NotificationsProvider } from '@mantine/notifications';
-import { RecoilRoot } from 'recoil';
+import { useEffect } from 'react';
+import { RecoilRoot, RecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 
 export function mantineRecoilWrap(children: JSX.Element) {
   return (
@@ -17,4 +18,30 @@ export function mantineRecoilWrap(children: JSX.Element) {
       </RecoilRoot>
     </ColorSchemeProvider>
   );
+}
+
+/*
+ * Generate a functional component that can hardcode the value of a recoil atom
+ */
+export function getMockRecoilState<T>(atom: RecoilState<T>, value: T) {
+  return () => {
+    const setMockState = useSetRecoilState(atom);
+    useEffect(() => {
+      setMockState(value);
+    }, [setMockState]);
+    return null;
+  };
+}
+
+/*
+ * Generate a functional component that can observe changes to a recoil atom
+ */
+export function getRecoilObserver<T>(atom: RecoilState<T>, onChange: (value: T) => void) {
+  return () => {
+    const value = useRecoilValue(atom);
+    useEffect(() => {
+      onChange(value);
+    }, [value]);
+    return null;
+  };
 }

--- a/components/MeasureUpload.tsx
+++ b/components/MeasureUpload.tsx
@@ -1,0 +1,46 @@
+import { Dropzone } from '@mantine/dropzone';
+import { showNotification } from '@mantine/notifications';
+import { Grid, Center, Text } from '@mantine/core';
+import { IconFileImport, IconFileCheck, IconAlertCircle } from '@tabler/icons';
+import { useSetRecoilState, useRecoilValue } from 'recoil';
+import { measureBundleState } from '../state/atoms/measureBundle';
+
+function dropzoneChildren() {
+  const measureBundle = useRecoilValue(measureBundleState);
+  return (
+    <Grid justify="center">
+      <Grid.Col span={12}>
+        <Center>{measureBundle ? <IconFileCheck size={80} /> : <IconFileImport size={80} />}</Center>
+      </Grid.Col>
+      <Grid.Col>
+        <Center>
+          <Text size="xl" inline>
+            {measureBundle ? measureBundle.name : 'Drag a Measure Bundle JSON file here or click to select files'}
+          </Text>
+        </Center>
+      </Grid.Col>
+    </Grid>
+  );
+}
+
+export default function MeasureUpload() {
+  const setMeasureBundle = useSetRecoilState(measureBundleState);
+  return (
+    <Dropzone
+      onDrop={files => setMeasureBundle(files[0])}
+      onReject={files =>
+        showNotification({
+          id: 'failed-upload',
+          icon: <IconAlertCircle />,
+          title: 'File upload failed',
+          message: `Could not upload file: ${files[0].file['path']}. ${files[0].errors[0].message}`,
+          color: 'red'
+        })
+      }
+      accept={['.json']}
+      multiple={false}
+    >
+      {() => dropzoneChildren()}
+    </Dropzone>
+  );
+}

--- a/components/MeasureUpload.tsx
+++ b/components/MeasureUpload.tsx
@@ -6,7 +6,7 @@ import { useSetRecoilState, useRecoilValue } from 'recoil';
 import { measureBundleState } from '../state/atoms/measureBundle';
 
 function DropzoneChildren() {
-  const measureBundle = useRecoilValue(measureBundleState);
+  const measureBundle = useRecoilValue<null | File>(measureBundleState);
   return (
     <Grid justify="center">
       <Grid.Col span={12}>

--- a/components/MeasureUpload.tsx
+++ b/components/MeasureUpload.tsx
@@ -5,7 +5,7 @@ import { IconFileImport, IconFileCheck, IconAlertCircle } from '@tabler/icons';
 import { useSetRecoilState, useRecoilValue } from 'recoil';
 import { measureBundleState } from '../state/atoms/measureBundle';
 
-function dropzoneChildren() {
+function DropzoneChildren() {
   const measureBundle = useRecoilValue(measureBundleState);
   return (
     <Grid justify="center">
@@ -40,7 +40,7 @@ export default function MeasureUpload() {
       accept={['.json']}
       multiple={false}
     >
-      {() => dropzoneChildren()}
+      {DropzoneChildren}
     </Dropzone>
   );
 }

--- a/components/MeasureUpload.tsx
+++ b/components/MeasureUpload.tsx
@@ -14,21 +14,9 @@ export default function MeasureUpload() {
       const bundle = JSON.parse(reader.result as string) as fhir4.Bundle;
       const numMeasures = bundle?.entry?.filter(r => r?.resource?.resourceType === 'Measure')?.length;
       if (bundle.resourceType !== 'Bundle') {
-        showNotification({
-          id: 'failed-upload',
-          icon: <IconAlertCircle />,
-          title: 'File upload failed',
-          message: `Uploaded file must contain a resource of type 'Bundle'`,
-          color: 'red'
-        });
+        rejectFile("Uploaded file must be a JSON FHIR Resource of type 'Bundle'");
       } else if (numMeasures !== 1) {
-        showNotification({
-          id: 'failed-upload',
-          icon: <IconAlertCircle />,
-          title: 'File upload failed',
-          message: `Uploaded bundle must contain exactly one resource of type 'Measure'`,
-          color: 'red'
-        });
+        rejectFile("Uploaded bundle must contain exactly one resource of type 'Measure'");
       } else {
         setMeasureBundle({
           name: file.name,
@@ -37,6 +25,20 @@ export default function MeasureUpload() {
       }
     };
     reader.readAsText(file);
+  }
+
+  function rejectFile(message: string) {
+    showNotification({
+      id: 'failed-upload',
+      icon: <IconAlertCircle />,
+      title: 'File upload failed',
+      message,
+      color: 'red'
+    });
+    setMeasureBundle({
+      name: '',
+      content: null
+    });
   }
   return (
     <Dropzone

--- a/components/MeasureUpload.tsx
+++ b/components/MeasureUpload.tsx
@@ -5,6 +5,28 @@ import { IconFileImport, IconFileCheck, IconAlertCircle } from '@tabler/icons';
 import { useSetRecoilState, useRecoilValue } from 'recoil';
 import { measureBundleState } from '../state/atoms/measureBundle';
 
+export default function MeasureUpload() {
+  const setMeasureBundle = useSetRecoilState(measureBundleState);
+  return (
+    <Dropzone
+      onDrop={files => setMeasureBundle(files[0])}
+      onReject={files =>
+        showNotification({
+          id: 'failed-upload',
+          icon: <IconAlertCircle />,
+          title: 'File upload failed',
+          message: `Could not upload file: ${files[0].file.name}. ${files[0].errors[0].message}`,
+          color: 'red'
+        })
+      }
+      accept={['.json']}
+      multiple={false}
+    >
+      {DropzoneChildren}
+    </Dropzone>
+  );
+}
+
 function DropzoneChildren() {
   const measureBundle = useRecoilValue<null | File>(measureBundleState);
   return (
@@ -20,27 +42,5 @@ function DropzoneChildren() {
         </Center>
       </Grid.Col>
     </Grid>
-  );
-}
-
-export default function MeasureUpload() {
-  const setMeasureBundle = useSetRecoilState(measureBundleState);
-  return (
-    <Dropzone
-      onDrop={files => setMeasureBundle(files[0])}
-      onReject={files =>
-        showNotification({
-          id: 'failed-upload',
-          icon: <IconAlertCircle />,
-          title: 'File upload failed',
-          message: `Could not upload file: ${files[0].file['path']}. ${files[0].errors[0].message}`,
-          color: 'red'
-        })
-      }
-      accept={['.json']}
-      multiple={false}
-    >
-      {DropzoneChildren}
-    </Dropzone>
   );
 }

--- a/components/MeasureUpload.tsx
+++ b/components/MeasureUpload.tsx
@@ -2,7 +2,7 @@ import { Dropzone } from '@mantine/dropzone';
 import { showNotification } from '@mantine/notifications';
 import { Grid, Center, Text } from '@mantine/core';
 import { IconFileImport, IconFileCheck, IconAlertCircle } from '@tabler/icons';
-import { useSetRecoilState, useRecoilValue, SetterOrUpdater } from 'recoil';
+import { useSetRecoilState, useRecoilValue } from 'recoil';
 import { measureBundleState } from '../state/atoms/measureBundle';
 
 export default function MeasureUpload() {
@@ -12,12 +12,21 @@ export default function MeasureUpload() {
     const reader = new FileReader();
     reader.onload = () => {
       const bundle = JSON.parse(reader.result as string) as fhir4.Bundle;
-      if (!(bundle.resourceType === 'Bundle')) {
+      const numMeasures = bundle?.entry?.filter(r => r.resource.resourceType === 'Measure').length;
+      if (bundle.resourceType !== 'Bundle') {
         showNotification({
           id: 'failed-upload',
           icon: <IconAlertCircle />,
           title: 'File upload failed',
-          message: `Uploaded file must contain a resource fo type 'Bundle'`,
+          message: `Uploaded file must contain a resource of type 'Bundle'`,
+          color: 'red'
+        });
+      } else if (numMeasures !== 1) {
+        showNotification({
+          id: 'failed-upload',
+          icon: <IconAlertCircle />,
+          title: 'File upload failed',
+          message: `Uploaded bundle must contain exactly one resource of type 'Measure'`,
           color: 'red'
         });
       } else {

--- a/components/MeasureUpload.tsx
+++ b/components/MeasureUpload.tsx
@@ -12,7 +12,7 @@ export default function MeasureUpload() {
     const reader = new FileReader();
     reader.onload = () => {
       const bundle = JSON.parse(reader.result as string) as fhir4.Bundle;
-      const numMeasures = bundle?.entry?.filter(r => r.resource.resourceType === 'Measure').length;
+      const numMeasures = bundle?.entry?.filter(r => r?.resource?.resourceType === 'Measure')?.length;
       if (bundle.resourceType !== 'Bundle') {
         showNotification({
           id: 'failed-upload',

--- a/package-lock.json
+++ b/package-lock.json
@@ -938,6 +938,14 @@
         "react-textarea-autosize": "^8.3.2"
       }
     },
+    "@mantine/dropzone": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@mantine/dropzone/-/dropzone-4.2.5.tgz",
+      "integrity": "sha512-Jt6oQF2/4ZMMev047BYkbs2ggTsepfWINj41rBGfQXeF9jarPA/kv0we8I0CCKSj2YDIIjHAxsR2U4KnkN75DQ==",
+      "requires": {
+        "react-dropzone": "^11.4.2"
+      }
+    },
     "@mantine/hooks": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-4.2.4.tgz",
@@ -952,9 +960,9 @@
       }
     },
     "@mantine/notifications": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@mantine/notifications/-/notifications-4.2.4.tgz",
-      "integrity": "sha512-BgiG8jMW6WStgHuuj/BSX6g8camSUY1iP5SFw0hFkseWW4Y/6IPbcshejGQKS7stkjoJZQVZGaXkJQGkZcWcpA==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@mantine/notifications/-/notifications-4.2.5.tgz",
+      "integrity": "sha512-Qb+Zs66N5u+nlO6cKWoQI+0b8Tp+0AzugtXGaTrhRq5kpjOdH6XwSDkSXpkLPHBUYGwlweuTkMrc2Md1FNORqg==",
       "requires": {
         "react-transition-group": "^4.4.2"
       }
@@ -1272,6 +1280,11 @@
       "requires": {
         "@sinonjs/commons": "^1.7.0"
       }
+    },
+    "@tabler/icons": {
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-1.68.0.tgz",
+      "integrity": "sha512-UseBEEhv7r+Drl3iZih7rkwqkfJJZscjd5ZvK1WdIIulQsBa+qE8WBDGdAO0RtjkCclEK88z9kC0s5wiVPIvkw=="
     },
     "@testing-library/dom": {
       "version": "8.13.0",
@@ -1932,6 +1945,11 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
+    },
+    "attr-accept": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.2.tgz",
+      "integrity": "sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg=="
     },
     "axe-core": {
       "version": "4.4.2",
@@ -3045,6 +3063,21 @@
       "dev": true,
       "requires": {
         "flat-cache": "^3.0.4"
+      }
+    },
+    "file-selector": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.4.0.tgz",
+      "integrity": "sha512-iACCiXeMYOvZqlF1kTiYINzgepRBymz1wwjiuup9u9nayhb6g4fSwiyJ/6adli+EPwrWtpgQAh2PoS7HukEGEg==",
+      "requires": {
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
       }
     },
     "fill-range": {
@@ -4852,6 +4885,16 @@
       "requires": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.22.0"
+      }
+    },
+    "react-dropzone": {
+      "version": "11.7.1",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-11.7.1.tgz",
+      "integrity": "sha512-zxCMwhfPy1olUEbw3FLNPLhAm/HnaYH5aELIEglRbqabizKAdHs0h+WuyOpmA+v1JXn0++fpQDdNfUagWt5hJQ==",
+      "requires": {
+        "attr-accept": "^2.2.2",
+        "file-selector": "^0.4.0",
+        "prop-types": "^15.8.1"
       }
     },
     "react-fast-compare": {

--- a/package.json
+++ b/package.json
@@ -16,10 +16,12 @@
   },
   "dependencies": {
     "@mantine/core": "^4.2.4",
+    "@mantine/dropzone": "^4.2.5",
     "@mantine/hooks": "^4.2.4",
     "@mantine/next": "^4.2.4",
-    "@mantine/notifications": "^4.2.4",
+    "@mantine/notifications": "^4.2.5",
     "@mantine/prism": "^4.2.4",
+    "@tabler/icons": "^1.68.0",
     "next": "12.1.6",
     "react": "18.1.0",
     "react-dom": "18.1.0",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,8 @@
 import type { NextPage } from 'next';
 import Head from 'next/head';
-import { AppShell, Header } from '@mantine/core';
+import { AppShell, Grid, Header } from '@mantine/core';
 import AbacusHeader from '../components/AbacusHeader';
+import MeasureUpload from '../components/MeasureUpload';
 
 const Home: NextPage = () => {
   return (
@@ -10,7 +11,11 @@ const Home: NextPage = () => {
         <title>FQM Testify: an ECQM Analysis Tool</title>
       </Head>
       <AppShell padding="md" header={<Header height={60}>{<AbacusHeader></AbacusHeader>}</Header>}>
-        <></>
+        <Grid>
+          <Grid.Col span={12}>
+            <MeasureUpload />
+          </Grid.Col>
+        </Grid>
       </AppShell>
     </>
   );

--- a/state/atoms/measureBundle.ts
+++ b/state/atoms/measureBundle.ts
@@ -1,9 +1,14 @@
 import { atom } from 'recoil';
 
+interface measureBundleStateType {
+  name: string;
+  content: fhir4.Bundle | null;
+}
+
 /**
  * Atom tracking and controlling the value of uploaded measure bundle
  */
-export const measureBundleState = atom<{ name: string; content: fhir4.Bundle | null }>({
+export const measureBundleState = atom<measureBundleStateType>({
   key: 'measureBundleState',
   default: {
     name: '',

--- a/state/atoms/measureBundle.ts
+++ b/state/atoms/measureBundle.ts
@@ -1,0 +1,9 @@
+import { atom } from 'recoil';
+
+/**
+ * Atom tracking and controlling the value of uploaded measure bundle
+ */
+export const measureBundleState = atom({
+  key: 'measureBundleState',
+  default: null
+});

--- a/state/atoms/measureBundle.ts
+++ b/state/atoms/measureBundle.ts
@@ -3,7 +3,10 @@ import { atom } from 'recoil';
 /**
  * Atom tracking and controlling the value of uploaded measure bundle
  */
-export const measureBundleState = atom<File | null>({
+export const measureBundleState = atom<{ name: string; content: fhir4.Bundle | null }>({
   key: 'measureBundleState',
-  default: null
+  default: {
+    name: '',
+    content: null
+  }
 });

--- a/state/atoms/measureBundle.ts
+++ b/state/atoms/measureBundle.ts
@@ -3,7 +3,7 @@ import { atom } from 'recoil';
 /**
  * Atom tracking and controlling the value of uploaded measure bundle
  */
-export const measureBundleState = atom({
+export const measureBundleState = atom<File | null>({
   key: 'measureBundleState',
   default: null
 });


### PR DESCRIPTION
# Summary
Added a file upload component that accepts .json files for measure upload

## New Behavior
The home screen now contains a file dropzone which will populate a global measure bundle recoil state on file drop

## Code Changes
- Added file dropzone component and testing
- Added some of Matt's recoil testing helper functions

# Testing Guidance
- Run `npm install` then `npm run check`
- Run `npm run dev`
- Click on the file dropzone and upload any .json file. Ensure the file icon changes as well as the text prompt to reflect the uploaded file name
- Add `maxSize={1}` on line 42 of `components/MeasureUpload.tsx`
- Now upload any .json file and endure an error notification appears with a helpful error message