### PR TITLE
Vs patch to use regex

### DIFF
--- a/components/MissingValueSetModal.tsx
+++ b/components/MissingValueSetModal.tsx
@@ -6,6 +6,8 @@ import { Modal, Alert, Text, List } from '@mantine/core';
 import { AlertCircle } from 'tabler-icons-react';
 import { useState } from 'react';
 
+const VSAC_REGEX = /http:\/\/cts\.nlm\.nih\.gov.*ValueSet/;
+
 export default function MissingValueSetModal() {
   const [measureBundle, setMeasureBundle] = useRecoilState(measureBundleState);
   const [missingValueSets, setMissingValueSets] = useState<string[]>([]);
@@ -55,7 +57,6 @@ export default function MissingValueSetModal() {
 async function identifyMissingValueSets(mb: fhir4.Bundle): Promise<string[]> {
   const allRequiredValuesets = new Set<string>();
   const includedValuesets = new Set<string>();
-  const VSAC_REGEX = /http:\/\/cts\.nlm\.nih\.gov.*ValueSet/;
 
   mb?.entry?.forEach(e => {
     if (e?.resource?.resourceType === 'ValueSet') {

--- a/components/MissingValueSetModal.tsx
+++ b/components/MissingValueSetModal.tsx
@@ -55,6 +55,7 @@ export default function MissingValueSetModal() {
 async function identifyMissingValueSets(mb: fhir4.Bundle): Promise<string[]> {
   const allRequiredValuesets = new Set<string>();
   const includedValuesets = new Set<string>();
+  const VSAC_REGEX = /http:\/\/cts\.nlm\.nih\.gov.*ValueSet/;
 
   mb?.entry?.forEach(e => {
     if (e?.resource?.resourceType === 'ValueSet') {
@@ -64,7 +65,9 @@ async function identifyMissingValueSets(mb: fhir4.Bundle): Promise<string[]> {
   const dataRequirements = await Calculator.calculateDataRequirements(mb);
   dataRequirements?.results?.dataRequirement?.forEach(dr => {
     dr?.codeFilter?.forEach(filter => {
-      filter.path === 'type' && allRequiredValuesets.add(filter.valueSet as string);
+      if (filter.valueSet && VSAC_REGEX.test(filter.valueSet)) {
+        allRequiredValuesets.add(filter.valueSet as string);
+      }
     });
   });
   const missingValuesets = Array.from(allRequiredValuesets).filter(vs => !includedValuesets.has(vs));


### PR DESCRIPTION
# Summary
Updated our method of identifying VSAC valuesets to use Regex

## New Behavior
Valuesets under `path: code` will now be included in required valuesets when checking if all required valuesets are included

## Code Changes
- Use a regex to check if a valueset is a VSAC valueset in `identifyMissingValuesets()` function

# Testing Guidance
- Try dropping a measure bundle missing a required valueset in the file dropzone and ensure you get a popup modal with a link to the missing valueset