### PR TITLE
Add button for download of patient testcase data as a patient bundle

### DIFF
--- a/__tests__/components/ResourceCreation/PatientCreation.test.tsx
+++ b/__tests__/components/ResourceCreation/PatientCreation.test.tsx
@@ -1,8 +1,13 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { mantineRecoilWrap, getMockRecoilState } from '../../helpers/testHelpers';
 import PatientCreation from '../../../components/ResourceCreation/PatientCreation';
 import { patientTestCaseState } from '../../../state/atoms/patientTestCase';
+import { download } from '../../../util/downloadUtil';
+
+jest.mock('../../../util/downloadUtil', () => ({
+  download: jest.fn()
+}));
 
 describe('PatientCreation', () => {
   const DEFAULT_PROPS = {
@@ -103,12 +108,48 @@ describe('PatientCreation', () => {
       )
     );
 
-    const deleteButton = screen.getByText(/delete patient/i) as HTMLButtonElement;
+    const deleteButton = screen.getByTestId('delete-patient-button') as HTMLButtonElement;
     expect(deleteButton).toBeInTheDocument();
 
     fireEvent.click(deleteButton);
 
     const testCaseList = screen.queryByTestId('patient-stack');
     expect(testCaseList).not.toBeInTheDocument();
+  });
+
+  it('should have download function called when download patient button is clicked', async () => {
+    const MockPatients = getMockRecoilState(patientTestCaseState, {
+      'example-pt': {
+        patient: {
+          resourceType: 'Patient',
+          name: [{ given: ['Test123'], family: 'Patient456' }]
+        },
+        resources: [
+          {
+            resourceType: 'Procedure',
+            id: 'test-id',
+            status: 'completed',
+            subject: {}
+          }
+        ]
+      }
+    });
+
+    render(
+      mantineRecoilWrap(
+        <>
+          <MockPatients />
+          <PatientCreation {...DEFAULT_PROPS} isPatientModalOpen={false} currentPatient={null} />
+        </>
+      )
+    );
+
+    const exportButton = screen.getByTestId('export-patient-button') as HTMLButtonElement;
+    expect(exportButton).toBeInTheDocument();
+
+    fireEvent.click(exportButton);
+    await waitFor(() => {
+      expect(download).toBeCalledTimes(1);
+    });
   });
 });

--- a/__tests__/components/ResourceCreation/TestResourceCreation.test.tsx
+++ b/__tests__/components/ResourceCreation/TestResourceCreation.test.tsx
@@ -85,7 +85,9 @@ describe('TestResourceCreation', () => {
         resources: [
           {
             resourceType: 'Procedure',
-            id: 'test-id'
+            id: 'test-id',
+            status: 'completed',
+            subject: {}
           }
         ]
       }
@@ -145,7 +147,9 @@ describe('TestResourceCreation', () => {
         resources: [
           {
             resourceType: 'Procedure',
-            id: 'test-id'
+            id: 'test-id',
+            status: 'completed',
+            subject: {}
           }
         ]
       }
@@ -185,7 +189,9 @@ describe('TestResourceCreation', () => {
         resources: [
           {
             resourceType: 'Procedure',
-            id: 'test-id'
+            id: 'test-id',
+            status: 'completed',
+            subject: {}
           }
         ]
       }

--- a/__tests__/utils/downloadUtil.test.ts
+++ b/__tests__/utils/downloadUtil.test.ts
@@ -1,0 +1,22 @@
+import { download } from '../../util/downloadUtil';
+import { getByTestId, waitFor } from '@testing-library/dom';
+import '@testing-library/jest-dom';
+
+describe('downloadUtil testing', () => {
+  test('test file download creates and removes link', async () => {
+    const prevCreateObj = URL.createObjectURL;
+    URL.createObjectURL = jest.fn().mockReturnValue('testURL');
+    download('testfilename', 'testcontents');
+    const link = getByTestId(document.body, 'temp-download-link');
+    expect(link).toHaveAttribute('download', 'testfilename');
+    expect(link).toHaveAttribute('href', 'testURL');
+
+    const onClick = jest.fn();
+    link.addEventListener('click', onClick);
+    await waitFor(() => {
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+    expect(link).not.toBeInTheDocument();
+    URL.createObjectURL = prevCreateObj; // reset mock of createObjectURL
+  });
+});

--- a/components/ResourceCreation/PatientCreation.tsx
+++ b/components/ResourceCreation/PatientCreation.tsx
@@ -3,12 +3,18 @@ import produce from 'immer';
 import CodeEditorModal from '../CodeEditorModal';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { patientTestCaseState } from '../../state/atoms/patientTestCase';
-import { createPatientResourceString, getPatientInfoString } from '../../util/fhir';
+import {
+  createPatientResourceString,
+  getPatientInfoString,
+  getPatientNameString,
+  createPatientBundleString
+} from '../../util/fhir';
 import { measurementPeriodState } from '../../state/atoms/measurementPeriod';
 import { selectedPatientState } from '../../state/atoms/selectedPatient';
-import { ChevronRight, ChevronDown } from 'tabler-icons-react';
+import { ChevronRight, ChevronDown, Download, Edit, Trash } from 'tabler-icons-react';
 import React from 'react';
 import TestResourceCreation from './TestResourceCreation';
+import { download } from '../../util/downloadUtil';
 
 interface PatientCreationProps {
   openPatientModal: (patientId?: string) => void;
@@ -51,6 +57,13 @@ function PatientCreation({
     });
 
     setCurrentPatients(nextPatientState);
+  };
+
+  const exportPatientTestCase = (id: string) => {
+    const bundleString: string = createPatientBundleString(currentPatients[id].patient, currentPatients[id].resources);
+    const filename = `${getPatientNameString(currentPatients[id].patient)}-${id}.json`;
+	// create and use hidden temporary download link in document
+    download(filename, bundleString);
   };
 
   const getInitialPatientResource = () => {
@@ -104,25 +117,37 @@ function PatientCreation({
                 </Button>
 
                 <Collapse in={selectedPatient === id} style={{ padding: '4px' }}>
-                  <Center>
-                    <Group>
-                      <Button
-                        onClick={() => {
-                          openPatientModal(id);
-                        }}
-                      >
-                        Edit Patient
-                      </Button>
-                      <Button
-                        onClick={() => {
-                          deletePatientTestCase(id);
-                        }}
-                        color="red"
-                      >
-                        Delete Patient
-                      </Button>
-                    </Group>
-                  </Center>
+                  <Group>
+                    <Button
+                      data-testid="export-patient-button"
+                      aria-label={'Export Patient'}
+                      onClick={() => {
+                        exportPatientTestCase(id);
+                      }}
+                    >
+                      <Download />
+                    </Button>
+                    <Button
+                      data-testid="edit-patient-button"
+                      aria-label={'Edit Patient'}
+                      onClick={() => {
+                        openPatientModal(id);
+                      }}
+                      color="gray"
+                    >
+                      <Edit />
+                    </Button>
+                    <Button
+                      data-testid="delete-patient-button"
+                      aria-label={'Delete Patient'}
+                      onClick={() => {
+                        deletePatientTestCase(id);
+                      }}
+                      color="red"
+                    >
+                      <Trash />
+                    </Button>
+                  </Group>
 
                   {selectedPatient === id && <TestResourceCreation />}
                 </Collapse>

--- a/components/ResourceCreation/TestResourceCreation.tsx
+++ b/components/ResourceCreation/TestResourceCreation.tsx
@@ -121,6 +121,7 @@ function TestResourceCreation() {
                   onClick={() => {
                     openResourceModal(resource.id);
                   }}
+                  color="gray"
                 >
                   Edit FHIR Resource
                 </Button>

--- a/state/atoms/patientTestCase.ts
+++ b/state/atoms/patientTestCase.ts
@@ -3,7 +3,7 @@ import { atom } from 'recoil';
 export interface TestCases {
   [patientId: string]: {
     patient: fhir4.Patient;
-    resources: fhir4.Resource[];
+    resources: fhir4.FhirResource[];
   };
 }
 

--- a/util/downloadUtil.ts
+++ b/util/downloadUtil.ts
@@ -1,0 +1,21 @@
+/**
+ * Creates a temporary download link in the document to download a file with the
+ * passed in filename and fileContents
+ * @param filename {String} the filename to download
+ * @param fileContents {String} the contents of the file to download
+ */
+export const download = (filename: string, fileContents: string) => {
+  const blob = new Blob([fileContents], { type: 'application/json+fhir' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.setAttribute('data-testid', 'temp-download-link');
+  link.setAttribute('href', url);
+  link.setAttribute('download', filename);
+  link.style.visibility = 'hidden';
+  document.body.appendChild(link);
+  // keep the link for one tick before click for testing
+  setTimeout(() => {
+    link.click();
+    document.body.removeChild(link);
+  });
+};

--- a/util/fhir.ts
+++ b/util/fhir.ts
@@ -38,7 +38,11 @@ export function createPatientResourceString(birthDate: string): string {
 }
 
 export function getPatientInfoString(patient: fhir4.Patient) {
-  return `${patient.name?.[0]?.given?.join(' ')} ${patient.name?.[0]?.family} (DOB: ${patient.birthDate})`;
+  return `${getPatientNameString(patient)} (DOB: ${patient.birthDate})`;
+}
+
+export function getPatientNameString(patient: fhir4.Patient) {
+  return `${patient.name?.[0]?.given?.join(' ')} ${patient.name?.[0]?.family}`;
 }
 
 /**
@@ -62,6 +66,33 @@ export function getDataRequirementFiltersString(dr: fhir4.DataRequirement, value
     return `${valueSets?.join('\n')}`;
   }
   return '';
+}
+
+/**
+ * Creates a string representing a patient bundle resource. Creates using a patient resource and
+ * an array of the patient's associated resources
+ * @param {Object} patient FHIR Patient object
+ * @param {Array} resources array of FHIR resources associated with the patient
+ * @returns {String} representation of a FHIR patient bundle resource
+ */
+export function createPatientBundleString(patient: fhir4.Patient, resources: fhir4.FhirResource[]): string {
+  const bundle: fhir4.Bundle = {
+    type: 'transaction',
+    resourceType: 'Bundle',
+    id: uuidv4(),
+    entry: [
+      {
+        resource: patient
+      }
+    ]
+  };
+  resources.forEach(resource => {
+    const entry: fhir4.BundleEntry = {
+      resource: resource
+    };
+    bundle.entry?.push(entry);
+  });
+  return JSON.stringify(bundle, null, 2);
 }
 
 /**


### PR DESCRIPTION
# Summary
Adds a button and logic for download of a test case in the form of a patient bundle. 

## New Behavior

## Code Changes


# Testing Guidance
Run unit tests with `npm run test`
Run `npm run dev` and try download at `localhost:3000` by:
- Adding a bundle with drag and drop
- Creating and saving a patient
- Expand the patient and select a resource to save to the patient
- Click the download button
- Confirm that the downloaded resource contains the patient and resources

Experiment with variations on the above