### PR TITLE
Fix patient resource editing functionality

### DIFF
--- a/components/ResourceCreation/PatientCreation.tsx
+++ b/components/ResourceCreation/PatientCreation.tsx
@@ -42,7 +42,7 @@ function PatientCreation({
 
       // Create a new state object using immer without needing to shallow clone the entire previous object
       const nextPatientState = produce(currentPatients, draftState => {
-        draftState[patientId] = { patient: pt, resources: [] };
+        draftState[patientId] = { patient: pt, resources: currentPatients[patientId]?.resources ?? [] };
       });
 
       setCurrentPatients(nextPatientState);
@@ -73,7 +73,7 @@ function PatientCreation({
   const getInitialPatientResource = () => {
     if (isPatientModalOpen) {
       if (currentPatient) {
-        return JSON.stringify(currentPatients[currentPatient], null, 2);
+        return JSON.stringify(currentPatients[currentPatient].patient, null, 2);
       } else {
         // Default to age 21 at time of measurement period, if specified
         const birthDate = measurementPeriod.start ? new Date(measurementPeriod.start) : new Date();


### PR DESCRIPTION
# Summary

Fixes patient editing so it gives you the resource instead of the recoil state object for the patient. 

## New Behavior

Functional patient editing. No longer wipes out the resources added to the patient when saving a change to the patient.

## Code Changes

Fixes in `PatientCreation.tsx`.

# Testing Guidance

- Create a patient.
- Add resources to the patient.
- Edit patient resource. Note that you just see the Patient resource in the code edit.
- Make a change to the patient (ex. birthday) and save.
- Note that resources are not wiped out.