### PR TITLE
Delete patient test case bug fix

### DIFF
--- a/components/ResourceCreation/PatientCreation.tsx
+++ b/components/ResourceCreation/PatientCreation.tsx
@@ -146,7 +146,7 @@ function PatientCreation({
                       aria-label={'Delete Patient'}
                       onClick={() => {
                         deletePatientTestCase(id);
-                        // Set the selected patient to null because the selected patient will not longer exist after it is deleted
+                        // Set the selected patient to null because the selected patient will no longer exist after it is deleted
                         setSelectedPatient(null);
                       }}
                       color="red"

--- a/components/ResourceCreation/PatientCreation.tsx
+++ b/components/ResourceCreation/PatientCreation.tsx
@@ -146,6 +146,7 @@ function PatientCreation({
                       aria-label={'Delete Patient'}
                       onClick={() => {
                         deletePatientTestCase(id);
+                        // Set the selected patient to null because the selected patient will not longer exist after it is deleted
                         setSelectedPatient(null);
                       }}
                       color="red"

--- a/components/ResourceCreation/PatientCreation.tsx
+++ b/components/ResourceCreation/PatientCreation.tsx
@@ -146,6 +146,7 @@ function PatientCreation({
                       aria-label={'Delete Patient'}
                       onClick={() => {
                         deletePatientTestCase(id);
+                        setSelectedPatient(null);
                       }}
                       color="red"
                     >


### PR DESCRIPTION
# Summary
This change makes sure that data elements for a test patient are not displayed after a test patient deletion.

## New Behavior
Now, when you expand a test patient and delete it, the data elements no longer stay there.

## Code Changes
After a test patient is deleted in PatientCreation.tsx, now the selected patient is set to null so that nothing for the selected patient is displayed because the selected patient no longer exists.

# Testing Guidance
- Upload a measure bundle.
- Create two patients.
- Expand one of them (data elements show up).
- Delete one of them (data elements should disappear now).