### PR TITLE
Delete confirmation

### DIFF
--- a/__tests__/components/ConfirmationModal.test.tsx
+++ b/__tests__/components/ConfirmationModal.test.tsx
@@ -1,0 +1,62 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ConfirmationModal, { ConfirmationModalProps } from '../../components/ConfirmationModal';
+
+describe('Confirmation Modal', () => {
+  it('should render a confirmation modal when set to open', () => {
+    const testConfirmationModalProps: ConfirmationModalProps = {
+      open: true,
+      onClose: jest.fn(),
+      onConfirm: jest.fn()
+    };
+    render(<ConfirmationModal {...testConfirmationModalProps} />);
+
+    const confirmationModal = screen.getByRole('dialog');
+    expect(confirmationModal).toBeInTheDocument();
+  });
+
+  it('should not render a confirmation modal when not set to open', () => {
+    const testConfirmationModalProps: ConfirmationModalProps = {
+      open: false,
+      onClose: jest.fn(),
+      onConfirm: jest.fn()
+    };
+    render(<ConfirmationModal {...testConfirmationModalProps} />);
+
+    const confirmationModal = screen.queryByRole('dialog');
+    expect(confirmationModal).not.toBeInTheDocument();
+  });
+
+  it('should call on delete patient test case when yes button is clicked', () => {
+    const testConfirmationModalProps: ConfirmationModalProps = {
+      open: true,
+      onClose: jest.fn(),
+      onConfirm: jest.fn()
+    };
+    render(<ConfirmationModal {...testConfirmationModalProps} />);
+
+    const yesButton = screen.getByTestId('yes-button') as HTMLButtonElement;
+    expect(yesButton).toBeInTheDocument();
+
+    fireEvent.click(yesButton);
+
+    expect(testConfirmationModalProps.onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not call on delete patient test case when cancel button is clicked', () => {
+    const testConfirmationModalProps: ConfirmationModalProps = {
+      open: true,
+      onClose: jest.fn(),
+      onConfirm: jest.fn()
+    };
+    render(<ConfirmationModal {...testConfirmationModalProps} />);
+
+    const cancelButton = screen.getByTestId('cancel-button') as HTMLButtonElement;
+    expect(cancelButton).toBeInTheDocument();
+
+    fireEvent.click(cancelButton);
+
+    expect(testConfirmationModalProps.onConfirm).toHaveBeenCalledTimes(0);
+    expect(testConfirmationModalProps.onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/components/ResourceCreation/PatientCreation.test.tsx
+++ b/__tests__/components/ResourceCreation/PatientCreation.test.tsx
@@ -88,7 +88,7 @@ describe('PatientCreation', () => {
     expect(testPatientLabel).toBeInTheDocument();
   });
 
-  it('should delete patient when button is clicked', () => {
+  it('should render confirmation modal when delete button is clicked', () => {
     const MockPatients = getMockRecoilState(patientTestCaseState, {
       'example-pt': {
         patient: {
@@ -113,8 +113,8 @@ describe('PatientCreation', () => {
 
     fireEvent.click(deleteButton);
 
-    const testCaseList = screen.queryByTestId('patient-stack');
-    expect(testCaseList).not.toBeInTheDocument();
+    const confirmationModal = screen.getByRole('dialog');
+    expect(confirmationModal).toBeInTheDocument();
   });
 
   it('should have download function called when download patient button is clicked', async () => {

--- a/components/ConfirmationModal.tsx
+++ b/components/ConfirmationModal.tsx
@@ -1,26 +1,32 @@
-import { Modal, useMantineColorScheme, Button, Center, Group, Text, Grid } from '@mantine/core';
-import { json, jsonParseLinter } from '@codemirror/lang-json';
-import { useState } from 'react';
-import { initial } from 'lodash';
+import { Modal, Button, Center, Group, Text } from '@mantine/core';
+import { AlertTriangle } from 'tabler-icons-react';
 
 export interface ConfirmationModalProps {
   open: boolean;
   onClose: () => void;
-  onSave: (value: string) => void;
-  title?: string;
-  initialValue?: string;
+  onConfirm: () => void;
+  title?: string | null;
 }
 
-export default function ConfirmationModal({
-  open = true,
-  onClose,
-  title,
-  onSave,
-  initialValue = ''
-}: ConfirmationModalProps) {
+export default function ConfirmationModal({ open = true, onClose, title, onConfirm }: ConfirmationModalProps) {
   return (
-    <Modal data-testid="confirmation-modal" opened={open} onClose={onClose} title={title}>
-      Hello
+    <Modal data-testid="confirmation-modal" opened={open} onClose={onClose} withCloseButton={false} size="30%">
+      <Center>
+        <AlertTriangle color="red" />
+        <Text size="sm" weight={700}>
+          &nbsp;{title}
+        </Text>
+      </Center>
+      <Center>
+        <Group style={{ paddingTop: '12px' }}>
+          <Button data-testid="yes-button" onClick={() => onConfirm()}>
+            Yes
+          </Button>
+          <Button data-testid="cancel-button" color="gray" onClick={onClose}>
+            Cancel
+          </Button>
+        </Group>
+      </Center>
     </Modal>
   );
 }

--- a/components/ConfirmationModal.tsx
+++ b/components/ConfirmationModal.tsx
@@ -1,4 +1,4 @@
-import { Modal, Button, Center, Group, Text } from '@mantine/core';
+import { Modal, Button, Center, Group, Text, Grid } from '@mantine/core';
 import { AlertTriangle } from 'tabler-icons-react';
 
 export interface ConfirmationModalProps {
@@ -10,23 +10,37 @@ export interface ConfirmationModalProps {
 
 export default function ConfirmationModal({ open = true, onClose, title, onConfirm }: ConfirmationModalProps) {
   return (
-    <Modal data-testid="confirmation-modal" opened={open} onClose={onClose} withCloseButton={false} size="30%">
-      <Center>
-        <AlertTriangle color="red" />
-        <Text size="sm" weight={700}>
-          &nbsp;{title}
-        </Text>
-      </Center>
-      <Center>
-        <Group style={{ paddingTop: '12px' }}>
-          <Button data-testid="yes-button" onClick={() => onConfirm()}>
-            Yes
-          </Button>
-          <Button data-testid="cancel-button" color="gray" onClick={onClose}>
-            Cancel
-          </Button>
-        </Group>
-      </Center>
+    <Modal
+      data-testid="confirmation-modal"
+      zIndex={2}
+      overflow="outside"
+      opened={open}
+      onClose={onClose}
+      withCloseButton={false}
+      size="lg"
+    >
+      <Grid align="center" justify="center">
+        <Grid.Col>
+          <Center>
+            <AlertTriangle color="red" size={35} />
+            <Text size="sm" weight={700} align="center">
+              &nbsp;{title}
+            </Text>
+          </Center>
+        </Grid.Col>
+        <Grid.Col>
+          <Center>
+            <Group style={{ paddingTop: '5px' }}>
+              <Button data-testid="yes-button" onClick={() => onConfirm()}>
+                Yes
+              </Button>
+              <Button data-testid="cancel-button" color="gray" onClick={onClose}>
+                Cancel
+              </Button>
+            </Group>
+          </Center>
+        </Grid.Col>
+      </Grid>
     </Modal>
   );
 }

--- a/components/ConfirmationModal.tsx
+++ b/components/ConfirmationModal.tsx
@@ -1,0 +1,26 @@
+import { Modal, useMantineColorScheme, Button, Center, Group, Text, Grid } from '@mantine/core';
+import { json, jsonParseLinter } from '@codemirror/lang-json';
+import { useState } from 'react';
+import { initial } from 'lodash';
+
+export interface ConfirmationModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSave: (value: string) => void;
+  title?: string;
+  initialValue?: string;
+}
+
+export default function ConfirmationModal({
+  open = true,
+  onClose,
+  title,
+  onSave,
+  initialValue = ''
+}: ConfirmationModalProps) {
+  return (
+    <Modal data-testid="confirmation-modal" opened={open} onClose={onClose} title={title}>
+      Hello
+    </Modal>
+  );
+}

--- a/components/ResourceCreation/PatientCreation.tsx
+++ b/components/ResourceCreation/PatientCreation.tsx
@@ -128,7 +128,7 @@ function PatientCreation({
         onClose={closeConfirmationModal}
         title={getConfirmationModalText(selectedPatient)}
         onConfirm={() => deletePatientTestCase(selectedPatient)}
-      ></ConfirmationModal>
+     />
       {Object.keys(currentPatients).length > 0 && (
         <>
           <Stack data-testid="patient-stack">

--- a/components/ResourceCreation/PatientCreation.tsx
+++ b/components/ResourceCreation/PatientCreation.tsx
@@ -128,7 +128,7 @@ function PatientCreation({
         onClose={closeConfirmationModal}
         title={getConfirmationModalText(selectedPatient)}
         onConfirm={() => deletePatientTestCase(selectedPatient)}
-     />
+      />
       {Object.keys(currentPatients).length > 0 && (
         <>
           <Stack data-testid="patient-stack">

--- a/components/ResourceCreation/PatientCreation.tsx
+++ b/components/ResourceCreation/PatientCreation.tsx
@@ -1,4 +1,4 @@
-import { Button, Collapse, Group, Modal, Stack } from '@mantine/core';
+import { Button, Collapse, Group, Stack } from '@mantine/core';
 import produce from 'immer';
 import CodeEditorModal from '../CodeEditorModal';
 import { useRecoilState, useRecoilValue } from 'recoil';
@@ -61,15 +61,16 @@ function PatientCreation({
     setIsConfirmationModalOpen(false);
   };
 
-  const deletePatientTestCase = (id: string) => {
-    const nextPatientState = produce(currentPatients, draftState => {
-      delete draftState[id];
-    });
-
-    setCurrentPatients(nextPatientState);
-    // Set the selected patient to null because the selected patient will not longer exist after it is deleted
-    setSelectedPatient(null);
-    closeConfirmationModal();
+  const deletePatientTestCase = (id: string | null) => {
+    if (id !== null) {
+      const nextPatientState = produce(currentPatients, draftState => {
+        delete draftState[id];
+      });
+      setCurrentPatients(nextPatientState);
+      // Set the selected patient to null because the selected patient will not longer exist after it is deleted
+      setSelectedPatient(null);
+      closeConfirmationModal();
+    }
   };
 
   const exportPatientTestCase = (id: string) => {
@@ -104,6 +105,15 @@ function PatientCreation({
       setSelectedPatient(patientId);
     }
   };
+
+  const getConfirmationModalText = (patientId: string | null) => {
+    let patientName;
+    if (patientId !== null) {
+      const patient = currentPatients[patientId].patient;
+      patientName = getPatientNameString(patient);
+    }
+    return `Are you sure you want to delete ${patientName || 'this patient'}?`;
+  };
   return (
     <>
       <CodeEditorModal
@@ -116,8 +126,8 @@ function PatientCreation({
       <ConfirmationModal
         open={isConfirmationModalOpen}
         onClose={closeConfirmationModal}
-        title="Confirm Patient Deletion"
-        onSave={deletePatientTestCase}
+        title={getConfirmationModalText(selectedPatient)}
+        onConfirm={() => deletePatientTestCase(selectedPatient)}
       ></ConfirmationModal>
       {Object.keys(currentPatients).length > 0 && (
         <>
@@ -161,9 +171,7 @@ function PatientCreation({
                     <Button
                       data-testid="delete-patient-button"
                       aria-label={'Delete Patient'}
-                      onClick={() => {
-                        openConfirmationModal();
-                      }}
+                      onClick={openConfirmationModal}
                       color="red"
                     >
                       <Trash />


### PR DESCRIPTION
# Summary
This PR allows users to confirm that they want to delete a patient test case. 

## New Behavior
Before, when a user would click the delete patient test case button, it just immediately deleted that patient. Now, when a user clicks the delete button, a modal pops up that allows the user to confirm that they wanted to delete the patient. This confirmation modal was created in a new file to allow for the confirmation modal functionality to be used in other areas of the web application, if needed. 

## Code Changes
- New component `ConfirmationModal.tsx` that allows users to confirm whether they wanted to to complete a specific action.
- Confirmation modal rendered in `PatientCreation.tsx` that allows users to confirm whether they wanted to delete a patient test case. 
- Added tests for all the above. 

# Testing Guidance
**Confirm Delete**
1. Upload a measure bundle and create some test patients.
2. Select one of the patients and take note of their name.
3. Click the delete button-- a modal should render confirming if you want to delete this patient (should display correct patient name).
4. Click 'Yes'-- should close modal and that patient should be deleted. 

**Cancel Delete**
1. Upload a measure bundle and create some test patients.
2. Select one of the patients and take note of their name.
3. Click the delete button-- a modal should render confirming if you want to delete this patient (should display correct patient name).
4. Click 'Cancel'-- should close modal and that patient should still be there. 