### PR TITLE
Aligned edit and delete test case resource buttons 

### DIFF
--- a/__tests__/components/ResourceCreation/TestResourceCreation.test.tsx
+++ b/__tests__/components/ResourceCreation/TestResourceCreation.test.tsx
@@ -104,7 +104,7 @@ describe('TestResourceCreation', () => {
       )
     );
 
-    const editResourceButton = screen.getByRole('button', { name: 'Edit FHIR Resource' });
+    const editResourceButton = screen.getByTestId('edit-resource-button') as HTMLButtonElement;
     fireEvent.click(editResourceButton);
 
     const modal = screen.getByRole('dialog', { name: 'Edit FHIR Resource' });
@@ -172,10 +172,10 @@ describe('TestResourceCreation', () => {
     const procedureResource = screen.getByText(/1. Procedure/i);
     expect(procedureResource).toBeInTheDocument();
 
-    const editResourceButton = screen.getByRole('button', { name: 'Edit FHIR Resource' });
+    const editResourceButton = screen.getByTestId('edit-resource-button') as HTMLButtonElement;
     expect(editResourceButton).toBeInTheDocument();
 
-    const deleteResourceButton = screen.getByRole('button', { name: 'Delete Resource' });
+    const deleteResourceButton = screen.getByTestId('delete-resource-button') as HTMLButtonElement;
     expect(deleteResourceButton).toBeInTheDocument();
   });
 
@@ -208,7 +208,7 @@ describe('TestResourceCreation', () => {
       )
     );
 
-    const deleteResourceButton = screen.getByRole('button', { name: 'Delete Resource' });
+    const deleteResourceButton = screen.getByTestId('delete-resource-button') as HTMLButtonElement;
     expect(deleteResourceButton).toBeInTheDocument();
 
     fireEvent.click(deleteResourceButton);

--- a/components/ResourceCreation/TestResourceCreation.tsx
+++ b/components/ResourceCreation/TestResourceCreation.tsx
@@ -1,4 +1,4 @@
-import { Button, Group, Paper, Text } from '@mantine/core';
+import { Button, Grid, Group, Paper, Text } from '@mantine/core';
 import { useCallback, useEffect, useState } from 'react';
 import produce from 'immer';
 import { useRecoilState, useRecoilValue } from 'recoil';
@@ -8,6 +8,7 @@ import { selectedDataRequirementState } from '../../state/atoms/selectedDataRequ
 import { patientTestCaseState } from '../../state/atoms/patientTestCase';
 import { createFHIRResourceString } from '../../util/fhir';
 import { selectedPatientState } from '../../state/atoms/selectedPatient';
+import { Edit, Trash } from 'tabler-icons-react';
 
 function TestResourceCreation() {
   const [currentTestCases, setCurrentTestCases] = useRecoilState(patientTestCaseState);
@@ -101,6 +102,8 @@ function TestResourceCreation() {
     return undefined;
   };
 
+  const alternatingColor = ['#e3e3e3', '#ffffff'];
+
   return (
     <>
       <CodeEditorModal
@@ -114,26 +117,37 @@ function TestResourceCreation() {
         <>
           <h3>Test Case Resources:</h3>
           {currentTestCases[selectedPatient].resources.map((resource, idx) => (
-            <Paper key={resource.id} withBorder p="md">
-              <Group>
-                <Text>{`${idx + 1}. ${resource.resourceType}`}</Text>
-                <Button
-                  onClick={() => {
-                    openResourceModal(resource.id);
-                  }}
-                  color="gray"
-                >
-                  Edit FHIR Resource
-                </Button>
-                <Button
-                  onClick={() => {
-                    deleteResource(resource.id);
-                  }}
-                  color="red"
-                >
-                  Delete Resource
-                </Button>
-              </Group>
+            <Paper
+              key={resource.id}
+              withBorder
+              p="md"
+              sx={{ backgroundColor: alternatingColor[idx % alternatingColor.length] }}
+            >
+              <Grid justify="space-between">
+                <Group>
+                  <Text>{`${idx + 1}. ${resource.resourceType}`}</Text>
+                </Group>
+                <Group>
+                  <Button
+                    onClick={() => {
+                      openResourceModal(resource.id);
+                    }}
+                    color="gray"
+                    data-testid="edit-resource-button"
+                  >
+                    <Edit />
+                  </Button>
+                  <Button
+                    onClick={() => {
+                      deleteResource(resource.id);
+                    }}
+                    color="red"
+                    data-testid="delete-resource-button"
+                  >
+                    <Trash />
+                  </Button>
+                </Group>
+              </Grid>
             </Paper>
           ))}
         </>


### PR DESCRIPTION
## Summary
This PR consolidates FHIR resource buttons to be right-aligned icon buttons. 

## New Behavior
The code behaves the same, the delete resource and edit resource buttons are now just right-aligned and are icons. The resources also alternate colors (white and light gray). The unit tests for these buttons were updated to reflect the icon change. 

## Code Changes
TestResourceCreation.tsx was changed to include the styling changes described above. TestResourcereation.test.tsx was changed to reflect the button changes.

## Testing Guidance
1. Upload a measure bundle and create a test patient.
2. Click on the patient created and add some FHIR resources to the patient by selecting them on the side and clicking save. 
3. Do this for a few FHIR resources- they should be displayed under the test patient in a list that has alternating colors and whose delete and edit buttons are now right-aligned icons.
4. Re-size the window a bit to make sure that the display is relatively consistent and doesn't look horrible. 