### PR TITLE
Resource code and display name added

### DIFF
--- a/__tests__/components/ResourceCreation/TestResourceCreation.test.tsx
+++ b/__tests__/components/ResourceCreation/TestResourceCreation.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { mantineRecoilWrap, getMockRecoilState } from '../../helpers/testHelpers';
 import TestResourceCreation from '../../../components/ResourceCreation/TestResourceCreation';
@@ -137,7 +137,7 @@ describe('TestResourceCreation', () => {
     expect(resourceInfo).not.toBeInTheDocument();
   });
 
-  it('should render test resource list when populated', async () => {
+  it('should render test resource list when populated', () => {
     const MockResources = getMockRecoilState(patientTestCaseState, {
       'example-test-case': {
         patient: {
@@ -164,7 +164,7 @@ describe('TestResourceCreation', () => {
     });
     const MockSelectedPatient = getMockRecoilState(selectedPatientState, 'example-test-case');
 
-    const baseDom = render(
+    render(
       mantineRecoilWrap(
         <>
           <MockResources />

--- a/__tests__/components/ResourceCreation/TestResourceCreation.test.tsx
+++ b/__tests__/components/ResourceCreation/TestResourceCreation.test.tsx
@@ -164,7 +164,7 @@ describe('TestResourceCreation', () => {
     });
     const MockSelectedPatient = getMockRecoilState(selectedPatientState, 'example-test-case');
 
-    render(
+    const baseDom = render(
       mantineRecoilWrap(
         <>
           <MockResources />
@@ -182,15 +182,6 @@ describe('TestResourceCreation', () => {
 
     const resourceCode = screen.getByText(/123: Colectomy/i);
     expect(resourceCode).toBeInTheDocument();
-
-    await act(async () => {
-      fireEvent.mouseOver(resourceCode);
-    });
-
-    waitFor(() => {
-      const resourceCodes = screen.getAllByText(/123: Colectomy/i);
-      expect(resourceCodes).toHaveLength(2);
-    });
 
     const editResourceButton = screen.getByTestId('edit-resource-button') as HTMLButtonElement;
     expect(editResourceButton).toBeInTheDocument();

--- a/__tests__/components/ResourceCreation/TestResourceCreation.test.tsx
+++ b/__tests__/components/ResourceCreation/TestResourceCreation.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { mantineRecoilWrap, getMockRecoilState } from '../../helpers/testHelpers';
 import TestResourceCreation from '../../../components/ResourceCreation/TestResourceCreation';
@@ -137,7 +137,7 @@ describe('TestResourceCreation', () => {
     expect(resourceInfo).not.toBeInTheDocument();
   });
 
-  it('should render test resource list when populated', () => {
+  it('should render test resource list when populated', async () => {
     const MockResources = getMockRecoilState(patientTestCaseState, {
       'example-test-case': {
         patient: {
@@ -149,7 +149,15 @@ describe('TestResourceCreation', () => {
             resourceType: 'Procedure',
             id: 'test-id',
             status: 'completed',
-            subject: {}
+            subject: {},
+            code: {
+              coding: [
+                {
+                  code: '123',
+                  display: 'Colectomy'
+                }
+              ]
+            }
           }
         ]
       }
@@ -171,6 +179,18 @@ describe('TestResourceCreation', () => {
 
     const procedureResource = screen.getByText(/1. Procedure/i);
     expect(procedureResource).toBeInTheDocument();
+
+    const resourceCode = screen.getByText(/123: Colectomy/i);
+    expect(resourceCode).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.mouseOver(resourceCode);
+    });
+
+    waitFor(() => {
+      const resourceCodes = screen.getAllByText(/123: Colectomy/i);
+      expect(resourceCodes).toHaveLength(2);
+    });
 
     const editResourceButton = screen.getByTestId('edit-resource-button') as HTMLButtonElement;
     expect(editResourceButton).toBeInTheDocument();

--- a/__tests__/utils/fhir.test.ts
+++ b/__tests__/utils/fhir.test.ts
@@ -164,10 +164,10 @@ const TEST_MEASURE_BUNDLE_WITH_EXPANSION: fhir4.Bundle = {
 };
 
 const RESOURCE_WITH_NO_SUMMARY: fhir4.Resource = {
-  resourceType: 'Prodcedure'
+  resourceType: 'Procedure'
 };
 
-const RESOURCE_WITH_NO_CODE_PATH: fhir4.Resource = {
+const RESOURCE_WITH_NO_CODE: fhir4.Resource = {
   resourceType: 'Procedure',
   id: 'procedure-id'
 };
@@ -242,6 +242,22 @@ const PROCEDURE_RESOURCE_WITH_TWO_CODES: fhir4.Procedure = {
   }
 };
 
+const MEASURE_REPORT_WITH_ID: fhir4.MeasureReport = {
+  resourceType: 'MeasureReport',
+  id: 'measure-report-id',
+  type: 'individual',
+  status: 'complete',
+  measure: '',
+  period: {
+    start: '',
+    end: ''
+  },
+  text: {
+    div: 'test123',
+    status: 'additional'
+  }
+};
+
 describe('getDataRequirementFiltersString', () => {
   test('returns an empty string for resource with no valuesets', () => {
     expect(getDataRequirementFiltersString(DATA_REQUIREMENT_WITH_NO_VALUE_SETS, VS_MAP)).toEqual('');
@@ -263,8 +279,11 @@ describe('getFhirResourceSummary', () => {
   test('returns an empty string for resource with no code, display, or id', () => {
     expect(getFhirResourceSummary(RESOURCE_WITH_NO_SUMMARY)).toEqual('');
   });
+  test('returns the resource id for resource with no code', () => {
+    expect(getFhirResourceSummary(RESOURCE_WITH_NO_CODE)).toEqual('(procedure-id)');
+  });
   test('returns the resource id for resource with no primary code path', () => {
-    expect(getFhirResourceSummary(RESOURCE_WITH_NO_CODE_PATH)).toEqual('(procedure-id)');
+    expect(getFhirResourceSummary(MEASURE_REPORT_WITH_ID)).toEqual('(measure-report-id)');
   });
   test('returns the code and display for resource with both', () => {
     expect(getFhirResourceSummary(PROCEDURE_RESOURCE_WITH_FULL_SUMMARY)).toEqual(
@@ -274,7 +293,7 @@ describe('getFhirResourceSummary', () => {
   test('returns only the code when the display does not exist but the code does', () => {
     expect(getFhirResourceSummary(PROCEDURE_RESOURCE_WITH_CODE)).toEqual('(123)');
   });
-  test('returns only the display when the code does not exist but the code does', () => {
+  test('returns only the display when the code does not exist but the display does', () => {
     expect(getFhirResourceSummary(PROCEDURE_RESOURCE_WITH_DISPLAY)).toEqual(
       '(This is an example of display text for a Procedure resource.)'
     );

--- a/__tests__/utils/fhir.test.ts
+++ b/__tests__/utils/fhir.test.ts
@@ -1,4 +1,9 @@
-import { createFHIRResourceString, getDataRequirementFiltersString, createPatientBundle } from '../../util/fhir';
+import {
+  createFHIRResourceString,
+  getDataRequirementFiltersString,
+  createPatientBundle,
+  getFhirResourceSummary
+} from '../../util/fhir';
 
 const VS_MAP = { testvs: 'test vs name' };
 const DATA_REQUIREMENT_WITH_NO_VALUE_SETS = {
@@ -158,6 +163,85 @@ const TEST_MEASURE_BUNDLE_WITH_EXPANSION: fhir4.Bundle = {
   ]
 };
 
+const RESOURCE_WITH_NO_SUMMARY: fhir4.Resource = {
+  resourceType: 'Prodcedure'
+};
+
+const RESOURCE_WITH_NO_CODE_PATH: fhir4.Resource = {
+  resourceType: 'Procedure',
+  id: 'procedure-id'
+};
+
+const PROCEDURE_RESOURCE_WITH_FULL_SUMMARY: fhir4.Procedure = {
+  resourceType: 'Procedure',
+  id: 'procedure-id',
+  status: 'completed',
+  code: {
+    coding: [
+      {
+        code: '123',
+        display: 'This is an example of display text for a Procedure resource.'
+      }
+    ]
+  },
+  subject: {
+    reference: 'procedure-reference'
+  }
+};
+
+const PROCEDURE_RESOURCE_WITH_CODE: fhir4.Procedure = {
+  resourceType: 'Procedure',
+  id: 'procedure-id',
+  status: 'completed',
+  code: {
+    coding: [
+      {
+        code: '123'
+      }
+    ]
+  },
+  subject: {
+    reference: 'procedure-reference'
+  }
+};
+
+const PROCEDURE_RESOURCE_WITH_DISPLAY: fhir4.Procedure = {
+  resourceType: 'Procedure',
+  id: 'procedure-id',
+  status: 'completed',
+  code: {
+    coding: [
+      {
+        display: 'This is an example of display text for a Procedure resource.'
+      }
+    ]
+  },
+  subject: {
+    reference: 'procedure-reference'
+  }
+};
+
+const PROCEDURE_RESOURCE_WITH_TWO_CODES: fhir4.Procedure = {
+  resourceType: 'Procedure',
+  id: 'procedure-id',
+  status: 'completed',
+  code: {
+    coding: [
+      {
+        code: '123',
+        display: 'Display1'
+      },
+      {
+        code: '456',
+        display: 'Display2'
+      }
+    ]
+  },
+  subject: {
+    reference: 'procedure-reference'
+  }
+};
+
 describe('getDataRequirementFiltersString', () => {
   test('returns an empty string for resource with no valuesets', () => {
     expect(getDataRequirementFiltersString(DATA_REQUIREMENT_WITH_NO_VALUE_SETS, VS_MAP)).toEqual('');
@@ -172,6 +256,31 @@ describe('getDataRequirementFiltersString', () => {
     expect(getDataRequirementFiltersString(OBSERVATION_DATA_REQUIREMENT_WITH_CODE_AND_VALUESET, VS_MAP)).toEqual(
       'test vs name (testvs)\ntest display'
     );
+  });
+});
+
+describe('getFhirResourceSummary', () => {
+  test('returns an empty string for resource with no code, display, or id', () => {
+    expect(getFhirResourceSummary(RESOURCE_WITH_NO_SUMMARY)).toEqual('');
+  });
+  test('returns the resource id for resource with no primary code path', () => {
+    expect(getFhirResourceSummary(RESOURCE_WITH_NO_CODE_PATH)).toEqual('(procedure-id)');
+  });
+  test('returns the code and display for resource with both', () => {
+    expect(getFhirResourceSummary(PROCEDURE_RESOURCE_WITH_FULL_SUMMARY)).toEqual(
+      '(123: This is an example of display text for a Procedure resource.)'
+    );
+  });
+  test('returns only the code when the display does not exist but the code does', () => {
+    expect(getFhirResourceSummary(PROCEDURE_RESOURCE_WITH_CODE)).toEqual('(123)');
+  });
+  test('returns only the display when the code does not exist but the code does', () => {
+    expect(getFhirResourceSummary(PROCEDURE_RESOURCE_WITH_DISPLAY)).toEqual(
+      '(This is an example of display text for a Procedure resource.)'
+    );
+  });
+  test('returns only the first code and display when there are multiple codes', () => {
+    expect(getFhirResourceSummary(PROCEDURE_RESOURCE_WITH_TWO_CODES)).toEqual('(123: Display1)');
   });
 });
 

--- a/components/ResourceCreation/TestResourceCreation.tsx
+++ b/components/ResourceCreation/TestResourceCreation.tsx
@@ -1,4 +1,4 @@
-import { Button, Grid, Group, Paper, Text } from '@mantine/core';
+import { Button, Grid, Group, Paper, Text, Tooltip } from '@mantine/core';
 import { useCallback, useEffect, useState } from 'react';
 import produce from 'immer';
 import { useRecoilState, useRecoilValue } from 'recoil';
@@ -6,7 +6,7 @@ import CodeEditorModal from '../CodeEditorModal';
 import { measureBundleState } from '../../state/atoms/measureBundle';
 import { selectedDataRequirementState } from '../../state/atoms/selectedDataRequirement';
 import { patientTestCaseState } from '../../state/atoms/patientTestCase';
-import { createFHIRResourceString } from '../../util/fhir';
+import { createFHIRResourceString, getFhirResourceString } from '../../util/fhir';
 import { selectedPatientState } from '../../state/atoms/selectedPatient';
 import { Edit, Trash } from 'tabler-icons-react';
 
@@ -113,7 +113,7 @@ function TestResourceCreation() {
         onSave={updateResource}
         initialValue={getInitialResource()}
       />
-      {selectedPatient && currentTestCases[selectedPatient].resources.length > 0 && (
+      {selectedPatient && selectedDataRequirement && currentTestCases[selectedPatient].resources.length > 0 && (
         <>
           <h3>Test Case Resources:</h3>
           {currentTestCases[selectedPatient].resources.map((resource, idx) => (
@@ -124,9 +124,20 @@ function TestResourceCreation() {
               sx={{ backgroundColor: alternatingColor[idx % alternatingColor.length] }}
             >
               <Grid justify="space-between">
-                <Group>
-                  <Text>{`${idx + 1}. ${resource.resourceType}`}</Text>
-                </Group>
+                <Grid.Col span={10}>
+                  <Tooltip
+                    wrapLines
+                    width={500}
+                    withArrow
+                    transition="fade"
+                    transitionDuration={200}
+                    label={getFhirResourceString(resource)}
+                  >
+                    <Text lineClamp={1}>{`${idx + 1}. ${resource.resourceType} ${getFhirResourceString(
+                      resource
+                    )}`}</Text>
+                  </Tooltip>
+                </Grid.Col>
                 <Group>
                   <Button
                     onClick={() => {

--- a/components/ResourceCreation/TestResourceCreation.tsx
+++ b/components/ResourceCreation/TestResourceCreation.tsx
@@ -6,7 +6,7 @@ import CodeEditorModal from '../CodeEditorModal';
 import { measureBundleState } from '../../state/atoms/measureBundle';
 import { selectedDataRequirementState } from '../../state/atoms/selectedDataRequirement';
 import { patientTestCaseState } from '../../state/atoms/patientTestCase';
-import { createFHIRResourceString, getFhirResourceString } from '../../util/fhir';
+import { createFHIRResourceString, getFhirResourceSummary } from '../../util/fhir';
 import { selectedPatientState } from '../../state/atoms/selectedPatient';
 import { Edit, Trash } from 'tabler-icons-react';
 
@@ -131,9 +131,9 @@ function TestResourceCreation() {
                     withArrow
                     transition="fade"
                     transitionDuration={200}
-                    label={getFhirResourceString(resource)}
+                    label={<Text align="center">{getFhirResourceSummary(resource)} </Text>}
                   >
-                    <Text lineClamp={1}>{`${idx + 1}. ${resource.resourceType} ${getFhirResourceString(
+                    <Text lineClamp={1}>{`${idx + 1}. ${resource.resourceType} ${getFhirResourceSummary(
                       resource
                     )}`}</Text>
                   </Tooltip>

--- a/components/ResourceCreation/TestResourceCreation.tsx
+++ b/components/ResourceCreation/TestResourceCreation.tsx
@@ -132,6 +132,7 @@ function TestResourceCreation() {
                     transition="fade"
                     transitionDuration={200}
                     label={<Text align="center">{getFhirResourceSummary(resource)} </Text>}
+                    disabled={getFhirResourceSummary(resource) === ''}
                   >
                     <Text lineClamp={1}>{`${idx + 1}. ${resource.resourceType} ${getFhirResourceSummary(
                       resource

--- a/package-lock.json
+++ b/package-lock.json
@@ -5791,7 +5791,7 @@
     "stack-utils": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
-      "integrity": "sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true,
       "requires": {
         "escape-string-regexp": "^2.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2113,6 +2113,11 @@
         "color-convert": "^2.0.1"
       }
     },
+    "antlr4": {
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.9.3.tgz",
+      "integrity": "sha512-qNy2odgsa0skmNMCuxzXhM4M8J1YDaPv3TI+vCdnOAanu0N982wBrSqziDKRDctEZLZy9VffqIZXc0UGjjSP/g=="
+    },
     "anymatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
@@ -2638,6 +2643,11 @@
           }
         }
       }
+    },
+    "date-fns": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
     },
     "dayjs": {
       "version": "1.11.2",
@@ -3325,8 +3335,7 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esquery": {
       "version": "1.4.0",
@@ -3452,6 +3461,42 @@
       "dev": true,
       "requires": {
         "bser": "2.1.1"
+      }
+    },
+    "fhirpath": {
+      "version": "2.14.6",
+      "resolved": "https://registry.npmjs.org/fhirpath/-/fhirpath-2.14.6.tgz",
+      "integrity": "sha512-iQ6qOCI/e2LjWUDuaIlNUQfhEGwU+84oyEng8aXL9KaSlo4LMvVod7udfOeZ62qUwJvDGNrvCoXa1pe/36XagQ==",
+      "requires": {
+        "@lhncbc/ucum-lhc": "^4.1.3",
+        "antlr4": "~4.9.3",
+        "commander": "^2.18.0",
+        "date-fns": "^1.30.1",
+        "js-yaml": "^3.13.1"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        }
       }
     },
     "file-entry-cache": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5785,13 +5785,12 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
     "stack-utils": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "integrity": "sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==",
       "dev": true,
       "requires": {
         "escape-string-regexp": "^2.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1777,7 +1777,7 @@
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
     "@types/lodash": {
@@ -2196,13 +2196,13 @@
     "ast-types-flow": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
-      "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
+      "integrity": "sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==",
       "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
     },
     "atob": {
@@ -2437,7 +2437,7 @@
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
       "dev": true
     },
     "collect-v8-coverage": {
@@ -2478,7 +2478,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
     "convert-source-map": {
@@ -2571,7 +2571,7 @@
     "css.escape": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
-      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
       "dev": true
     },
     "cssom": {
@@ -2610,7 +2610,7 @@
     "csv-stringify": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-1.1.2.tgz",
-      "integrity": "sha1-d6QVJlgbzjOA8SsA18W7rHDIK1g=",
+      "integrity": "sha512-3NmNhhd+AkYs5YtM1GEh01VR6PKj6qch2ayfQaltx5xpcAdThjnbbI5eT8CzRVpXfGKAxnmrSYLsNl/4f3eWiw==",
       "requires": {
         "lodash.get": "~4.4.2"
       }
@@ -2672,13 +2672,13 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==",
       "dev": true
     },
     "dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
-      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+      "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
       "dev": true
     },
     "deep-is": {
@@ -2706,7 +2706,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "dev": true
     },
     "detect-newline": {
@@ -2805,7 +2805,7 @@
     "duplexer2": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
       "requires": {
         "readable-stream": "^2.0.2"
       },
@@ -2813,7 +2813,7 @@
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+          "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
         },
         "readable-stream": {
           "version": "2.3.7",
@@ -2895,7 +2895,7 @@
     "emitter-component": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/emitter-component/-/emitter-component-1.1.1.tgz",
-      "integrity": "sha1-Bl4tvtaVm/RwZ57avq95gdEAOrY="
+      "integrity": "sha512-G+mpdiAySMuB7kesVRLuyvYRqDmshB7ReKEVuyBPkzQlmiDiLrt7hHHIy4Aff552bgknVN7B2/d3lzhGO5dvpQ=="
     },
     "emittery": {
       "version": "0.10.2",
@@ -2983,7 +2983,7 @@
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
     },
     "escape-string-regexp": {
       "version": "4.0.0",
@@ -3007,7 +3007,7 @@
         "levn": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-          "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+          "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
           "dev": true,
           "requires": {
             "prelude-ls": "~1.1.2",
@@ -3031,7 +3031,7 @@
         "prelude-ls": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-          "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+          "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
           "dev": true
         },
         "type-check": {
@@ -3208,7 +3208,7 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
           "dev": true
         }
       }
@@ -3387,7 +3387,7 @@
     "exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
       "dev": true
     },
     "expect": {
@@ -3442,7 +3442,7 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
     "fastq": {
@@ -3540,7 +3540,7 @@
     "find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
       "dev": true,
       "requires": {
         "locate-path": "^2.0.0"
@@ -3598,7 +3598,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
     "fsevents": {
@@ -3629,7 +3629,7 @@
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
       "dev": true
     },
     "functions-have-names": {
@@ -3737,7 +3737,7 @@
     "hamt_plus": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
-      "integrity": "sha1-4hwlKWjH4zsg9qGwlM2FeHomVgE="
+      "integrity": "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA=="
     },
     "handlebars": {
       "version": "4.7.7",
@@ -3937,7 +3937,7 @@
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true
     },
     "indent-string": {
@@ -3949,7 +3949,7 @@
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "dev": true,
       "requires": {
         "once": "^1.3.0",
@@ -3980,7 +3980,7 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true
     },
     "is-bigint": {
@@ -4029,7 +4029,7 @@
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true
     },
     "is-finite": {
@@ -4061,7 +4061,7 @@
     "is-integer": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.7.tgz",
-      "integrity": "sha1-a96Bqs3feLZZtmKdYpytxRqIbVw=",
+      "integrity": "sha512-RPQc/s9yBHSvpi+hs9dYiJ2cuFeU6x3TyyIp8O2H6SKEltIvJOzRj9ToyvcStDvPR/pS4rxgr1oBFajQjZ2Szg==",
       "requires": {
         "is-finite": "^1.0.0"
       }
@@ -4148,12 +4148,12 @@
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
     },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
     "istanbul-lib-coverage": {
@@ -4735,7 +4735,7 @@
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
     "json5": {
@@ -4750,7 +4750,7 @@
     "jsonfile": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+      "integrity": "sha512-PKllAqbgLgxHaj8TElYymKCAgrASebJrWpTnEkOaTowt23VKXXN0sUeriJ+eh7y6ufb/CC5ap11pz71/cM0hUw==",
       "requires": {
         "graceful-fs": "^4.1.6"
       }
@@ -4820,7 +4820,7 @@
     "language-tags": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.5.tgz",
-      "integrity": "sha1-0yHbxNowuovzAk4ED6XBRmH5GTo=",
+      "integrity": "sha512-qJhlO9cGXi6hBGKoxEG/sKZDAHD5Hnu9Hs4WbOY3pCWXDhw0N8x1NenNzm2EnNLkLkk7J2SdxAkDSbb6ftT+UQ==",
       "dev": true,
       "requires": {
         "language-subtag-registry": "~0.3.2"
@@ -4859,7 +4859,7 @@
     "locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
       "dev": true,
       "requires": {
         "p-locate": "^2.0.0",
@@ -4874,7 +4874,7 @@
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
     },
     "lodash.merge": {
       "version": "4.6.2",
@@ -4907,7 +4907,7 @@
     "lz-string": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
-      "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
+      "integrity": "sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==",
       "dev": true
     },
     "make-dir": {
@@ -5019,7 +5019,7 @@
     "multipipe": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-1.0.2.tgz",
-      "integrity": "sha1-zBPv2DPJzamfIk+GhGG44aP9k50=",
+      "integrity": "sha512-6uiC9OvY71vzSGX8lZvSqscE7ft9nPupJ8fMjrCNRAUy2LREUW42UL+V/NTrogr6rFgRydUrCX4ZitfpSNkSCQ==",
       "requires": {
         "duplexer2": "^0.1.2",
         "object-assign": "^4.1.0"
@@ -5033,7 +5033,7 @@
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
     "neo-async": {
@@ -5067,7 +5067,7 @@
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-      "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "dev": true
     },
     "node-releases": {
@@ -5100,7 +5100,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
     },
     "object-inspect": {
       "version": "1.12.0",
@@ -5172,7 +5172,7 @@
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "requires": {
         "wrappy": "1"
@@ -5213,7 +5213,7 @@
     "p-locate": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
       "dev": true,
       "requires": {
         "p-limit": "^1.1.0"
@@ -5222,7 +5222,7 @@
     "p-try": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
       "dev": true
     },
     "pako": {
@@ -5260,13 +5260,13 @@
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
       "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true
     },
     "path-key": {
@@ -5535,7 +5535,7 @@
     "readable-stream": {
       "version": "1.0.34",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.1",
@@ -5586,7 +5586,7 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true
     },
     "resolve": {
@@ -5807,7 +5807,7 @@
     "stream": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stream/-/stream-0.0.2.tgz",
-      "integrity": "sha1-f1Nj8Ff2WSxVlfALyAon9c7B8O8=",
+      "integrity": "sha512-gCq3NDI2P35B2n6t76YJuOp7d6cN/C7Rt0577l91wllh0sY9ZBuw9KaSGqH/b0hzn3CWWJbpbW0W0WvQ1H/Q7g==",
       "requires": {
         "emitter-component": "^1.1.1"
       }
@@ -5815,7 +5815,7 @@
     "stream-transform": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-0.1.2.tgz",
-      "integrity": "sha1-fY5rTgOsR4F3j4x5UXUBv7B2Kp8="
+      "integrity": "sha512-3HXId/0W8sktQnQM6rOZf2LuDDMbakMgAjpViLk758/h0br+iGqZFFfUxxJSqEvGvT742PyFr4v/TBXUtowdCg=="
     },
     "string-length": {
       "version": "4.0.2",
@@ -5839,7 +5839,7 @@
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+          "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
         },
         "readable-stream": {
           "version": "2.3.7",
@@ -5925,7 +5925,7 @@
     "string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
     },
     "strip-ansi": {
       "version": "6.0.1",
@@ -5939,7 +5939,7 @@
     "strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "dev": true
     },
     "strip-final-newline": {
@@ -6054,7 +6054,7 @@
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
     "throat": {
@@ -6066,12 +6066,12 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
     },
     "through2": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
-      "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
+      "integrity": "sha512-45Llu+EwHKtAZYTPPVn3XZHBgakWMN3rokhEv5hu596XP+cNgplMg+Gj+1nmAvj+L0K7+N49zBKx5rah5u0QIQ==",
       "requires": {
         "readable-stream": "~1.0.17",
         "xtend": "~2.1.1"
@@ -6086,7 +6086,7 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
       "dev": true
     },
     "to-regex-range": {
@@ -6459,7 +6459,7 @@
         "sax": {
           "version": "1.1.6",
           "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.6.tgz",
-          "integrity": "sha1-XWFr6KXmB9VOEUr65Vt+ry/MMkA="
+          "integrity": "sha512-8zci48uUQyfqynGDSkUMD7FCJB96hwLnlZOXlgs1l3TX+LW27t3psSWKUxC0fxVgA86i8tL4NwGcY1h/6t3ESg=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2501,7 +2501,7 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "cql-exec-fhir": {
-      "version": "github:projecttacoma/cql-exec-fhir#45a03f62c8af2905e562b8b1d4919725d585ce25",
+      "version": "github:projecttacoma/cql-exec-fhir#d48d57c3c7e199cbaa02e41418cad9efcd148b15",
       "from": "github:projecttacoma/cql-exec-fhir",
       "requires": {
         "@babel/runtime": "^7.17.2",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@uiw/react-codemirror": "^4.7.0",
     "dayjs": "^1.11.2",
     "ecqm-visualizers": "0.0.1",
+    "fhirpath": "^2.14.6",
     "file-saver": "^2.0.5",
     "fqm-execution": "^1.0.0-beta.2",
     "immer": "^9.0.14",

--- a/util/fhir.ts
+++ b/util/fhir.ts
@@ -5,6 +5,8 @@ import { parsedPrimaryCodePaths } from './primaryCodePaths';
 import _ from 'lodash';
 import { ReferencesMap } from './referencesMap';
 
+const fhirpath = require('fhirpath');
+
 export function createPatientResourceString(birthDate: string): string {
   const id = uuidv4();
 
@@ -32,6 +34,14 @@ export function createPatientResourceString(birthDate: string): string {
   };
 
   return JSON.stringify(pt, null, 2);
+}
+
+export function getFhirResourceString(resource: fhir4.Resource) {
+  const primaryCodePath = parsedPrimaryCodePaths[resource.resourceType].primaryCodePath;
+  return `(${fhirpath.evaluate(resource, `${primaryCodePath}.coding.code`)}: ${fhirpath.evaluate(
+    resource,
+    `${primaryCodePath}.coding.display`
+  )})`;
 }
 
 export function getPatientInfoString(patient: fhir4.Patient) {

--- a/util/fhir.ts
+++ b/util/fhir.ts
@@ -38,7 +38,7 @@ export function createPatientResourceString(birthDate: string): string {
 /**
  * Identifies the primary code path of a resource and constructs a string which displays
  * resource summary information depending on what is a available
- * @param resource {Object} a fhir DataRequirement object
+ * @param resource {Object} a fhir Resource object
  * @returns {String} displaying the code and display text, code, or id of the resource or nothing
  */
 export function getFhirResourceSummary(resource: fhir4.Resource) {

--- a/util/fhir.ts
+++ b/util/fhir.ts
@@ -4,8 +4,7 @@ import { ValueSetsMap } from '../state/selectors/valueSetsMap';
 import { parsedPrimaryCodePaths } from './primaryCodePaths';
 import _ from 'lodash';
 import { ReferencesMap } from './referencesMap';
-
-const fhirpath = require('fhirpath');
+import fhirpath from 'fhirpath';
 
 export function createPatientResourceString(birthDate: string): string {
   const id = uuidv4();
@@ -36,12 +35,26 @@ export function createPatientResourceString(birthDate: string): string {
   return JSON.stringify(pt, null, 2);
 }
 
-export function getFhirResourceString(resource: fhir4.Resource) {
-  const primaryCodePath = parsedPrimaryCodePaths[resource.resourceType].primaryCodePath;
-  return `(${fhirpath.evaluate(resource, `${primaryCodePath}.coding.code`)}: ${fhirpath.evaluate(
-    resource,
-    `${primaryCodePath}.coding.display`
-  )})`;
+/**
+ * Identifies the primary code path of a resource and constructs a string which displays
+ * resource summary information depending on what is a available
+ * @param resource {Object} a fhir DataRequirement object
+ * @returns {String} displaying the code and display text, code, or id of the resource or nothing
+ */
+export function getFhirResourceSummary(resource: fhir4.Resource) {
+  const primaryCodePath = parsedPrimaryCodePaths[resource.resourceType]?.primaryCodePath;
+
+  if (primaryCodePath) {
+    return `(${fhirpath.evaluate(resource, `${primaryCodePath}.coding.code`)}: ${fhirpath.evaluate(
+      resource,
+      `${primaryCodePath}.coding.display`
+    )})
+    `;
+  } else if (fhirpath.evaluate(resource, 'id')) {
+    return `(${fhirpath.evaluate(resource, 'id')})`;
+  } else {
+    return '';
+  }
 }
 
 export function getPatientInfoString(patient: fhir4.Patient) {

--- a/util/fhir.ts
+++ b/util/fhir.ts
@@ -43,13 +43,21 @@ export function createPatientResourceString(birthDate: string): string {
  */
 export function getFhirResourceSummary(resource: fhir4.Resource) {
   const primaryCodePath = parsedPrimaryCodePaths[resource.resourceType]?.primaryCodePath;
+  const resourceCode = `${fhirpath.evaluate(resource, `${primaryCodePath}.coding.code`)}`;
+  const resourceDisplay = `${fhirpath.evaluate(resource, `${primaryCodePath}.coding.display`)}`;
 
   if (primaryCodePath) {
-    return `(${fhirpath.evaluate(resource, `${primaryCodePath}.coding.code`)}: ${fhirpath.evaluate(
-      resource,
-      `${primaryCodePath}.coding.display`
-    )})
-    `;
+    if (resourceCode !== '' && resourceDisplay !== '') {
+      return `(${resourceCode}: ${resourceDisplay}`;
+    } else if (resourceCode !== '') {
+      return `(${resourceCode})`;
+    } else if (resourceDisplay !== '') {
+      return `(${resourceDisplay})`;
+    } else if (fhirpath.evaluate(resource, 'id')) {
+      return `(${fhirpath.evaluate(resource, 'id')})`;
+    } else {
+      return '';
+    }
   } else if (fhirpath.evaluate(resource, 'id')) {
     return `(${fhirpath.evaluate(resource, 'id')})`;
   } else {

--- a/util/fhir.ts
+++ b/util/fhir.ts
@@ -38,28 +38,28 @@ export function createPatientResourceString(birthDate: string): string {
 /**
  * Identifies the primary code path of a resource and constructs a string which displays
  * resource summary information depending on what is a available
- * @param resource {Object} a fhir Resource object
+ * @param resource {fhir4.Resource} a fhir Resource object
  * @returns {String} displaying the code and display text, code, or id of the resource or nothing
  */
 export function getFhirResourceSummary(resource: fhir4.Resource) {
   const primaryCodePath = parsedPrimaryCodePaths[resource.resourceType]?.primaryCodePath;
-  const resourceCode = `${fhirpath.evaluate(resource, `${primaryCodePath}.coding.code`)}`;
-  const resourceDisplay = `${fhirpath.evaluate(resource, `${primaryCodePath}.coding.display`)}`;
 
   if (primaryCodePath) {
-    if (resourceCode !== '' && resourceDisplay !== '') {
-      return `(${resourceCode}: ${resourceDisplay}`;
-    } else if (resourceCode !== '') {
+    const primaryCoding = fhirpath.evaluate(resource, `${primaryCodePath}.coding`)[0];
+    const resourceCode = primaryCoding?.code;
+    const resourceDisplay = primaryCoding?.display;
+
+    if (resourceCode && resourceDisplay) {
+      return `(${resourceCode}: ${resourceDisplay})`;
+    } else if (resourceCode) {
       return `(${resourceCode})`;
-    } else if (resourceDisplay !== '') {
+    } else if (resourceDisplay) {
       return `(${resourceDisplay})`;
-    } else if (fhirpath.evaluate(resource, 'id')) {
-      return `(${fhirpath.evaluate(resource, 'id')})`;
-    } else {
-      return '';
     }
-  } else if (fhirpath.evaluate(resource, 'id')) {
-    return `(${fhirpath.evaluate(resource, 'id')})`;
+  }
+
+  if (resource.id) {
+    return `(${resource.id})`;
   } else {
     return '';
   }


### PR DESCRIPTION
## Summary
Display the code and the first few words of the display text next to the test case resources in order to differentiate between resources that are of the same type. 

## New Behavior
When the display text is too long for the page, the text is cut off by an ellipses. To see the full text, the use can hover over the text with their mouse and the full text will appear in a popup "tooltip". 

## Code Changes
- `fhir.ts`: function added that takes a `Fhir4Resource` as a parameter and returns a string of that resource's code and display text. 
- `TestResourceCreation`: the `getFhirResourceString` in `fhir.ts` is called in order to display the code and display text next to the resourceType. In addition, this text is wrapped in a tooltip component so that the user can hover over the text to see the full text if it is cut off.
- `TestResourceCreation.test.tsx`: unit tests were added to test these changes.
- fhirpath added as a dependency.

## Testing Guidance
Run unit tests with `npm run test`. Then, try the following in the app:
1. Upload a measure bundle JSON file. 
2. Create a test patient.
3. Add some test case resources to that patient. The test case resources should display "ResourceType (code: display)".
4. Click the Edit button. Make sure that the values in the JSON for code and display match the ones shown. 
5. Add test case resources until you get one where the text is so long that it is cut off on the page with ellipses. 
6. Hover over the cut off text. You should see a popup that contains the full display text of the test case resource. 