### PR TITLE
Added confirmation modal to resource delete

### DIFF
--- a/__tests__/components/ResourceCreation/TestResourceCreation.test.tsx
+++ b/__tests__/components/ResourceCreation/TestResourceCreation.test.tsx
@@ -190,9 +190,9 @@ describe('TestResourceCreation', () => {
     expect(deleteResourceButton).toBeInTheDocument();
   });
 
-  it('should delete resource when button is clicked', () => {
-    const MockResources = getMockRecoilState(patientTestCaseState, {
-      'example-test-case': {
+  it('should render confirmation modal when delete button is clicked', () => {
+    const MockPatients = getMockRecoilState(patientTestCaseState, {
+      'example-pt': {
         patient: {
           resourceType: 'Patient',
           name: [{ given: ['Test123'], family: 'Patient456' }]
@@ -207,24 +207,25 @@ describe('TestResourceCreation', () => {
         ]
       }
     });
-    const MockSelectedPatient = getMockRecoilState(selectedPatientState, 'example-test-case');
+
+    const MockSelectedPatient = getMockRecoilState(selectedPatientState, 'example-pt');
 
     render(
       mantineRecoilWrap(
         <>
-          <MockResources />
+          <MockPatients />
           <MockSelectedPatient />
           <TestResourceCreation />
         </>
       )
     );
 
-    const deleteResourceButton = screen.getByTestId('delete-resource-button') as HTMLButtonElement;
-    expect(deleteResourceButton).toBeInTheDocument();
+    const deleteButton = screen.getByTestId('delete-resource-button') as HTMLButtonElement;
+    expect(deleteButton).toBeInTheDocument();
 
-    fireEvent.click(deleteResourceButton);
+    fireEvent.click(deleteButton);
 
-    const resourceInfo = screen.queryByText(/test case resources/i);
-    expect(resourceInfo).not.toBeInTheDocument();
+    const confirmationModal = screen.getByRole('dialog');
+    expect(confirmationModal).toBeInTheDocument();
   });
 });

--- a/components/ConfirmationModal.tsx
+++ b/components/ConfirmationModal.tsx
@@ -1,4 +1,5 @@
-import { Modal, Button, Center, Group, Text, Grid } from '@mantine/core';
+import { Modal, Button, Center, Group, Text, Grid, Space } from '@mantine/core';
+import { AlertTriangle } from 'tabler-icons-react';
 
 export interface ConfirmationModalProps {
   open: boolean;
@@ -20,9 +21,15 @@ export default function ConfirmationModal({ open = true, onClose, title, onConfi
     >
       <Grid align="center" justify="center">
         <Grid.Col>
-          <Text weight={700} align="center" lineClamp={2}>
-            {title}
-          </Text>
+          <Center>
+            <AlertTriangle color="red" size={35} />
+          </Center>
+          <Space></Space>
+          <Center>
+            <Text weight={700} align="center" lineClamp={2}>
+              {title}
+            </Text>
+          </Center>
         </Grid.Col>
         <Grid.Col>
           <Center>

--- a/components/ConfirmationModal.tsx
+++ b/components/ConfirmationModal.tsx
@@ -1,5 +1,4 @@
 import { Modal, Button, Center, Group, Text, Grid } from '@mantine/core';
-import { AlertTriangle } from 'tabler-icons-react';
 
 export interface ConfirmationModalProps {
   open: boolean;
@@ -21,12 +20,9 @@ export default function ConfirmationModal({ open = true, onClose, title, onConfi
     >
       <Grid align="center" justify="center">
         <Grid.Col>
-          <Center>
-            <AlertTriangle color="red" size={35} />
-            <Text size="sm" weight={700} align="center">
-              &nbsp;{title}
-            </Text>
-          </Center>
+          <Text weight={700} align="center" lineClamp={2}>
+            {title}
+          </Text>
         </Grid.Col>
         <Grid.Col>
           <Center>

--- a/components/ResourceCreation/TestResourceCreation.tsx
+++ b/components/ResourceCreation/TestResourceCreation.tsx
@@ -140,11 +140,11 @@ function TestResourceCreation() {
     return undefined;
   };
 
-  const getConfirmationModalText = (id: string | null) => {
-    if (selectedPatient && id) {
-      const resourceIndex = currentTestCases[selectedPatient].resources.findIndex(r => r.id === id);
+  const getConfirmationModalText = (resourceId: string | null) => {
+    if (selectedPatient && resourceId) {
+      const resourceIndex = currentTestCases[selectedPatient].resources.findIndex(r => r.id === resourceId);
       const resource = currentTestCases[selectedPatient].resources[resourceIndex];
-      return `Are you sure you want to delete ${resource.resourceType} ${getFhirResourceSummary(resource)}`;
+      return `Are you sure you want to delete ${resource.resourceType} ${getFhirResourceSummary(resource)}?`;
     }
   };
 

--- a/components/ResourceCreation/TestResourceCreation.tsx
+++ b/components/ResourceCreation/TestResourceCreation.tsx
@@ -10,6 +10,7 @@ import { createFHIRResourceString, getFhirResourceSummary } from '../../util/fhi
 import { selectedPatientState } from '../../state/atoms/selectedPatient';
 import { Edit, Trash } from 'tabler-icons-react';
 import { measurementPeriodState } from '../../state/atoms/measurementPeriod';
+import ConfirmationModal from '../ConfirmationModal';
 
 function TestResourceCreation() {
   const [currentTestCases, setCurrentTestCases] = useRecoilState(patientTestCaseState);
@@ -19,6 +20,29 @@ function TestResourceCreation() {
   const measureBundle = useRecoilValue(measureBundleState);
   const selectedPatient = useRecoilValue(selectedPatientState);
   const measurementPeriod = useRecoilValue(measurementPeriodState);
+  const [isConfirmationModalOpen, setIsConfirmationModalOpen] = useState(false);
+
+  const openConfirmationModal = useCallback(
+    (resourceId?: string) => {
+      if (
+        resourceId &&
+        selectedPatient &&
+        currentTestCases[selectedPatient].resources.findIndex(r => r.id === resourceId) >= 0
+      ) {
+        setCurrentResource(resourceId);
+      } else {
+        setCurrentResource(null);
+      }
+      setIsConfirmationModalOpen(true);
+    },
+    [currentTestCases, selectedPatient]
+  );
+
+  const closeConfirmationModal = () => {
+    setIsConfirmationModalOpen(false);
+    setCurrentResource(null);
+    setSelectedDataRequirement({ name: '', content: null });
+  };
 
   const openResourceModal = useCallback(
     (resourceId?: string) => {
@@ -75,7 +99,7 @@ function TestResourceCreation() {
     closeResourceModal();
   };
 
-  const deleteResource = (id?: string) => {
+  const deleteResource = (id: string | null) => {
     if (id && selectedPatient) {
       const resourceIndexToDelete = currentTestCases[selectedPatient].resources.findIndex(r => r.id === id);
       if (resourceIndexToDelete >= 0) {
@@ -85,6 +109,7 @@ function TestResourceCreation() {
         setCurrentTestCases(nextResourceState);
       }
     }
+    closeConfirmationModal();
   };
 
   const getInitialResource = () => {
@@ -115,6 +140,14 @@ function TestResourceCreation() {
     return undefined;
   };
 
+  const getConfirmationModalText = (id: string | null) => {
+    if (selectedPatient && id) {
+      const resourceIndex = currentTestCases[selectedPatient].resources.findIndex(r => r.id === id);
+      const resource = currentTestCases[selectedPatient].resources[resourceIndex];
+      return `Are you sure you want to delete ${resource.resourceType} ${getFhirResourceSummary(resource)}`;
+    }
+  };
+
   return (
     <>
       <CodeEditorModal
@@ -123,6 +156,12 @@ function TestResourceCreation() {
         title="Edit FHIR Resource"
         onSave={updateResource}
         initialValue={getInitialResource()}
+      />
+      <ConfirmationModal
+        open={isConfirmationModalOpen}
+        onClose={closeConfirmationModal}
+        title={getConfirmationModalText(currentResource)}
+        onConfirm={() => deleteResource(currentResource)}
       />
       {selectedPatient && selectedDataRequirement && currentTestCases[selectedPatient].resources.length > 0 && (
         <>
@@ -165,7 +204,7 @@ function TestResourceCreation() {
                   <Tooltip label="Delete FHIR Resource" openDelay={1000}>
                     <Button
                       onClick={() => {
-                        deleteResource(resource.id);
+                        openConfirmationModal(resource.id);
                       }}
                       color="red"
                       variant="outline"


### PR DESCRIPTION
# Summary
The confirmation modal is now rendered when a user wants to delete a data element.

## New Behavior
When a user clicks the delete button on a data element for a test patient, a confirmation modal appears that prompts the user whether or not they want to delete that data element. The resource type, code, and display text are shown in the modal so that the user knows which element they are deleting, but the text cuts off with ellipses after two lines in case the display text is really long. 

## Code Changes
- `TestResourceCreation.tsx`: code for rendering the confirmation modal when the user clicks the delete button.
- `TestResourceCreation.test.tsx`: unit test for the resource delete confirmation modal.
- `ConfirmationModal.tsx`: some styling changes for the confirmation modal itself so that it works for both patient deletion and resource deletion.

# Testing Guidance
**Functionality:**
1. Upload a measure bundle to fqm-testify and create a test patient.
2. Add some data elements to that test patient.
3. Pick a data element to delete and click the 'trash' icon. A modal should appear that says "Are you sure you want to delete" followed by the resourceType, code, and display text for that data element.
4. Click 'Yes'. The modal should close and that data element should no longer be in the test of test case resources for that patient.
5. Try this a couple times and make sure that every time the correct data element is being displayed in the modal and being deleted. Also make sure that if you click 'cancel' then that data element is not deleted.

**Appearance:**
- Before, the confirmation modal had an AlertTriangle icon in the display message, but it was very difficult to make it a uniform size in a reusable confirmation modal so I decided to take it out since we were likely going to change design elements of the app anyways. With that said, let me know if you think it should still include it or if you have any other design suggestions for the modal!
- I also cut the text in the modal off after two lines because some display string can be very long, but leave a comment if you think it would be more useful for the user to see that entire text, regardless of how long it is.
- Include any other changes you would make in how the confirmation modal is presented!