### PR TITLE
Render clause coverage HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ FQM-Testify allows for running measure calculation on a single test case for a g
 
 FQM-Testify enables users to run measure calculation on all test cases in addition to just one test case. Once a FHIR Measure and at least one test case are uploaded, the user can run measure calculation on all the created patients by clicking the Calculate Population Results button. Using calcuation from [the fqm-execution library](https://github.com/projecttacoma/fqm-execution), the population results for each patient appear in a population results table, with a row for each patient, labeled with the patient's name and date of birth. The population result table can be hidden or shown as well as regenerated if test cases are added.
 
+Once calculation has finished, the user can access an HTML representation of the clauses covered by the test cases that were passed into the calculation. This can be accessed by clicking on the "Show Clause Coverage" button.
+
 ## License
 
 Copyright 2022 The MITRE Corporation

--- a/__tests__/components/PopulationCalculation.test.tsx
+++ b/__tests__/components/PopulationCalculation.test.tsx
@@ -134,7 +134,9 @@ describe('PopulationCalculation', () => {
       }
     });
 
-    jest.spyOn(MeasureReportBuilder, 'buildMeasureReports').mockImplementation(() => {return [MOCK_MEASURE_REPORT]});
+    jest.spyOn(MeasureReportBuilder, 'buildMeasureReports').mockImplementation(() => {
+      return [MOCK_MEASURE_REPORT];
+    });
 
     jest.spyOn(Calculator, 'calculate').mockResolvedValue({
       results: []
@@ -204,7 +206,13 @@ describe('PopulationCalculation', () => {
       }
     });
 
-    jest.spyOn(MeasureReportBuilder, 'buildMeasureReports').mockImplementation(() => {return [MOCK_MEASURE_REPORT]});
+    jest.spyOn(MeasureReportBuilder, 'buildMeasureReports').mockImplementation(() => {
+      return [MOCK_MEASURE_REPORT];
+    });
+
+    jest.spyOn(Calculator, 'calculate').mockResolvedValue({
+      results: []
+    });
 
     await act(async () => {
       render(
@@ -270,7 +278,13 @@ describe('PopulationCalculation', () => {
       }
     });
 
-    jest.spyOn(MeasureReportBuilder, 'buildMeasureReports').mockImplementation(() => {return [MOCK_MEASURE_REPORT]});
+    jest.spyOn(MeasureReportBuilder, 'buildMeasureReports').mockImplementation(() => {
+      return [MOCK_MEASURE_REPORT];
+    });
+
+    jest.spyOn(Calculator, 'calculate').mockResolvedValue({
+      results: []
+    });
 
     await act(async () => {
       render(

--- a/__tests__/components/PopulationCalculation.test.tsx
+++ b/__tests__/components/PopulationCalculation.test.tsx
@@ -51,8 +51,21 @@ describe('PopulationCalculation', () => {
       )
     );
 
-    const calculateButton = screen.queryByTestId('show-table-button');
-    expect(calculateButton).not.toBeInTheDocument();
+    const showTableButton = screen.queryByTestId('show-table-button');
+    expect(showTableButton).not.toBeInTheDocument();
+  });
+
+  it('should not render Show Clause Coverage button by default', () => {
+    render(
+      mantineRecoilWrap(
+        <>
+          <PopulationCalculation />
+        </>
+      )
+    );
+
+    const showClauseCoverageButton = screen.queryByTestId('show-coverage-button');
+    expect(showClauseCoverageButton).not.toBeInTheDocument();
   });
 
   it('should render Calculate Population Results button when measure bundle is present and at least one patient created', () => {
@@ -217,6 +230,74 @@ describe('PopulationCalculation', () => {
     await waitFor(() => {
       const showTableButton = screen.getByTestId('show-table-button');
       expect(showTableButton).toBeInTheDocument();
+    });
+  });
+
+  it('should render Show Clause Coverage button once calculation has finished', async () => {
+    const DEFAULT_PROPS = {
+      closePatientModal: jest.fn(),
+      openPatientModal: jest.fn()
+    };
+
+    const MockPatients = getMockRecoilState(patientTestCaseState, {
+      'example-pt': {
+        patient: {
+          resourceType: 'Patient',
+          name: [{ given: ['Test123'], family: 'Patient456' }]
+        },
+        resources: [
+          {
+            resourceType: 'Procedure',
+            id: 'test-id',
+            status: 'completed',
+            subject: {}
+          }
+        ]
+      }
+    });
+
+    const MockMB = getMockRecoilState(measureBundleState, {
+      name: 'testName',
+      content: MOCK_BUNDLE
+    });
+
+    // Mock calculate data requirements because of the changing state
+    jest.spyOn(Calculator, 'calculateDataRequirements').mockResolvedValue({
+      results: {
+        resourceType: 'Library',
+        status: 'draft',
+        type: {}
+      }
+    });
+
+    jest.spyOn(Calculator, 'calculateMeasureReports').mockResolvedValue({
+      results: [MOCK_MEASURE_REPORT]
+    });
+
+    await act(async () => {
+      render(
+        mantineRecoilWrap(
+          <>
+            <MockPatients />
+            <MockMB />
+            <MeasureUpload />
+            <PatientCreation {...DEFAULT_PROPS} isPatientModalOpen={false} currentPatient={null} />
+            <PopulationCalculation />
+          </>
+        )
+      );
+    });
+
+    const calculateButton = screen.getByTestId('calculate-all-button');
+    expect(calculateButton).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(calculateButton);
+    });
+
+    await waitFor(() => {
+      const showClauseCoverageButton = screen.getByTestId('show-coverage-button');
+      expect(showClauseCoverageButton).toBeInTheDocument();
     });
   });
 });

--- a/__tests__/components/PopulationCalculation.test.tsx
+++ b/__tests__/components/PopulationCalculation.test.tsx
@@ -4,7 +4,7 @@ import { measureBundleState } from '../../state/atoms/measureBundle';
 import { patientTestCaseState } from '../../state/atoms/patientTestCase';
 import { getMockRecoilState, mantineRecoilWrap } from '../helpers/testHelpers';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { Calculator } from 'fqm-execution';
+import { Calculator, MeasureReportBuilder } from 'fqm-execution';
 import MeasureUpload from '../../components/MeasureUpload';
 import PatientCreation from '../../components/ResourceCreation/PatientCreation';
 
@@ -134,8 +134,10 @@ describe('PopulationCalculation', () => {
       }
     });
 
-    jest.spyOn(Calculator, 'calculateMeasureReports').mockResolvedValue({
-      results: [MOCK_MEASURE_REPORT]
+    jest.spyOn(MeasureReportBuilder, 'buildMeasureReports').mockImplementation(() => {return [MOCK_MEASURE_REPORT]});
+
+    jest.spyOn(Calculator, 'calculate').mockResolvedValue({
+      results: []
     });
 
     await act(async () => {
@@ -202,9 +204,7 @@ describe('PopulationCalculation', () => {
       }
     });
 
-    jest.spyOn(Calculator, 'calculateMeasureReports').mockResolvedValue({
-      results: [MOCK_MEASURE_REPORT]
-    });
+    jest.spyOn(MeasureReportBuilder, 'buildMeasureReports').mockImplementation(() => {return [MOCK_MEASURE_REPORT]});
 
     await act(async () => {
       render(
@@ -270,9 +270,7 @@ describe('PopulationCalculation', () => {
       }
     });
 
-    jest.spyOn(Calculator, 'calculateMeasureReports').mockResolvedValue({
-      results: [MOCK_MEASURE_REPORT]
-    });
+    jest.spyOn(MeasureReportBuilder, 'buildMeasureReports').mockImplementation(() => {return [MOCK_MEASURE_REPORT]});
 
     await act(async () => {
       render(

--- a/__tests__/helpers/testHelpers.tsx
+++ b/__tests__/helpers/testHelpers.tsx
@@ -2,6 +2,7 @@ import { ColorSchemeProvider, MantineProvider } from '@mantine/core';
 import { NotificationsProvider } from '@mantine/notifications';
 import { useEffect } from 'react';
 import { RecoilRoot, RecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+import { NextRouter } from 'next/router';
 
 export function mantineRecoilWrap(children: JSX.Element) {
   return (
@@ -43,5 +44,32 @@ export function getRecoilObserver<T>(atom: RecoilState<T>, onChange: (value: T) 
       onChange(value);
     }, [value]);
     return null;
+  };
+}
+
+export function createMockRouter(router: Partial<NextRouter>): NextRouter {
+  return {
+    basePath: '',
+    pathname: '/',
+    route: '/',
+    query: {},
+    asPath: '/',
+    back: jest.fn(),
+    beforePopState: jest.fn(),
+    prefetch: jest.fn().mockImplementation(() => Promise.resolve()),
+    push: jest.fn().mockImplementation(() => Promise.resolve(true)),
+    reload: jest.fn(),
+    replace: jest.fn(),
+    events: {
+      on: jest.fn(),
+      off: jest.fn(),
+      emit: jest.fn()
+    },
+    isLocaleDomain: false,
+    isFallback: false,
+    isReady: true,
+    defaultLocale: 'en',
+    isPreview: false,
+    ...router
   };
 }

--- a/__tests__/pages/measureId/coverage.test.tsx
+++ b/__tests__/pages/measureId/coverage.test.tsx
@@ -22,7 +22,7 @@ describe('coverage page rendering', () => {
     expect(backButton).toBeInTheDocument();
   });
 
-  it('should display header with measure id of calculated measure', async () => {
+  it('should display header with measure id of calculated measure, and HTML content', async () => {
     await act(async () => {
       render(
         <RouterContext.Provider
@@ -36,20 +36,6 @@ describe('coverage page rendering', () => {
     });
 
     expect(screen.getByText('Clause coverage for measure bundle: measure-EXM130-7.3.000')).toBeInTheDocument();
-  });
-
-  it('should display HTML content', async () => {
-    await act(async () => {
-      render(
-        <RouterContext.Provider
-          value={createMockRouter({
-            query: { measureId: 'measure-EXM130-7.3.000', clauseCoverageHTML: 'test html' }
-          })}
-        >
-          <ClauseCoveragePage />
-        </RouterContext.Provider>
-      );
-    });
     const textDiv = screen.getByText('test html');
     expect(textDiv).toBeInTheDocument();
   });

--- a/__tests__/pages/measureId/coverage.test.tsx
+++ b/__tests__/pages/measureId/coverage.test.tsx
@@ -10,7 +10,7 @@ describe('coverage page rendering', () => {
       render(
         <RouterContext.Provider
           value={createMockRouter({
-            query: { measureId: 'measure-EXM130-7.3.000' , clauseCoverageHTML: 'test html'}
+            query: { measureId: 'measure-EXM130-7.3.000', clauseCoverageHTML: 'test html' }
           })}
         >
           <ClauseCoveragePage />
@@ -38,7 +38,7 @@ describe('coverage page rendering', () => {
     expect(screen.getByText('Clause coverage for measure bundle: measure-EXM130-7.3.000')).toBeInTheDocument();
   });
 
-  it ('should display html content', async () => {
+  it('should display HTML content', async () => {
     await act(async () => {
       render(
         <RouterContext.Provider
@@ -67,6 +67,8 @@ describe('coverage page rendering', () => {
       );
     });
 
-    expect(screen.getByText('No clause coverage results available for measure bundle: measure-EXM130-7.3.000')).toBeInTheDocument();
-  })
+    expect(
+      screen.getByText('No clause coverage results available for measure bundle: measure-EXM130-7.3.000')
+    ).toBeInTheDocument();
+  });
 });

--- a/__tests__/pages/measureId/coverage.test.tsx
+++ b/__tests__/pages/measureId/coverage.test.tsx
@@ -10,7 +10,7 @@ describe('coverage page rendering', () => {
       render(
         <RouterContext.Provider
           value={createMockRouter({
-            query: { measureId: 'measure-EXM130-7.3.000' , html: ''}
+            query: { measureId: 'measure-EXM130-7.3.000' , clauseCoverageHTML: 'test html'}
           })}
         >
           <ClauseCoveragePage />
@@ -27,7 +27,7 @@ describe('coverage page rendering', () => {
       render(
         <RouterContext.Provider
           value={createMockRouter({
-            query: { measureId: 'measure-EXM130-7.3.000', html: '' }
+            query: { measureId: 'measure-EXM130-7.3.000', clauseCoverageHTML: 'test html' }
           })}
         >
           <ClauseCoveragePage />
@@ -35,6 +35,38 @@ describe('coverage page rendering', () => {
       );
     });
 
-    expect(screen.getByText('Clause coverage for measure: measure-EXM130-7.3.000')).toBeInTheDocument();
+    expect(screen.getByText('Clause coverage for measure bundle: measure-EXM130-7.3.000')).toBeInTheDocument();
   });
+
+  it ('should display html content', async () => {
+    await act(async () => {
+      render(
+        <RouterContext.Provider
+          value={createMockRouter({
+            query: { measureId: 'measure-EXM130-7.3.000', clauseCoverageHTML: 'test html' }
+          })}
+        >
+          <ClauseCoveragePage />
+        </RouterContext.Provider>
+      );
+    });
+    const textDiv = screen.getByText('test html');
+    expect(textDiv).toBeInTheDocument();
+  });
+
+  it('should display no clause coverage header when coverage html is not available', async () => {
+    await act(async () => {
+      render(
+        <RouterContext.Provider
+          value={createMockRouter({
+            query: { measureId: 'measure-EXM130-7.3.000', clauseCoverageHTML: undefined }
+          })}
+        >
+          <ClauseCoveragePage />
+        </RouterContext.Provider>
+      );
+    });
+
+    expect(screen.getByText('No clause coverage results available for measure bundle: measure-EXM130-7.3.000')).toBeInTheDocument();
+  })
 });

--- a/__tests__/pages/measureId/coverage.test.tsx
+++ b/__tests__/pages/measureId/coverage.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { RouterContext } from 'next/dist/shared/lib/router-context';
+import { createMockRouter } from '../../helpers/testHelpers';
+import ClauseCoveragePage from '../../../pages/[measureId]/coverage';
+
+describe('coverage page rendering', () => {
+  it('should display back button', async () => {
+    await act(async () => {
+      render(
+        <RouterContext.Provider
+          value={createMockRouter({
+            query: { measureId: 'measure-EXM130-7.3.000' }
+          })}
+        >
+          <ClauseCoveragePage />
+        </RouterContext.Provider>
+      );
+    });
+
+    const backButton = screen.getByRole('button', { name: 'Back Button' }) as HTMLButtonElement;
+    expect(backButton).toBeInTheDocument();
+  });
+
+  it('should display header with measure id of calculated measure', async () => {
+    await act(async () => {
+      render(
+        <RouterContext.Provider
+          value={createMockRouter({
+            query: { measureId: 'measure-EXM130-7.3.000' }
+          })}
+        >
+          <ClauseCoveragePage />
+        </RouterContext.Provider>
+      );
+    });
+
+    expect(screen.getByText('Clause coverage for measure: measure-EXM130-7.3.000')).toBeInTheDocument();
+  });
+});

--- a/__tests__/pages/measureId/coverage.test.tsx
+++ b/__tests__/pages/measureId/coverage.test.tsx
@@ -10,7 +10,7 @@ describe('coverage page rendering', () => {
       render(
         <RouterContext.Provider
           value={createMockRouter({
-            query: { measureId: 'measure-EXM130-7.3.000' }
+            query: { measureId: 'measure-EXM130-7.3.000' , html: ''}
           })}
         >
           <ClauseCoveragePage />
@@ -27,7 +27,7 @@ describe('coverage page rendering', () => {
       render(
         <RouterContext.Provider
           value={createMockRouter({
-            query: { measureId: 'measure-EXM130-7.3.000' }
+            query: { measureId: 'measure-EXM130-7.3.000', html: '' }
           })}
         >
           <ClauseCoveragePage />

--- a/components/BackButton.tsx
+++ b/components/BackButton.tsx
@@ -1,0 +1,23 @@
+import { useRouter } from 'next/router';
+import { Button } from '@mantine/core';
+import { ArrowNarrowLeft } from 'tabler-icons-react';
+
+const BackButton = () => {
+  const router = useRouter();
+  return (
+    <Button
+      data-testid="back-button"
+      aria-label="Back Button"
+      onClick={() => router.back()}
+      radius="md"
+      size="sm"
+      style={{
+        float: 'left'
+      }}
+    >
+      <ArrowNarrowLeft size="36" />
+    </Button>
+  );
+};
+
+export default BackButton;

--- a/components/BackButton.tsx
+++ b/components/BackButton.tsx
@@ -13,7 +13,8 @@ const BackButton = () => {
         radius="md"
         size="sm"
         style={{
-          float: 'left'
+          float: 'left',
+          marginLeft: '5px'
         }}
       >
         <ArrowNarrowLeft size="36" />

--- a/components/BackButton.tsx
+++ b/components/BackButton.tsx
@@ -1,22 +1,24 @@
 import { useRouter } from 'next/router';
-import { Button } from '@mantine/core';
+import { Button, Tooltip } from '@mantine/core';
 import { ArrowNarrowLeft } from 'tabler-icons-react';
 
 const BackButton = () => {
   const router = useRouter();
   return (
-    <Button
-      data-testid="back-button"
-      aria-label="Back Button"
-      onClick={() => router.back()}
-      radius="md"
-      size="sm"
-      style={{
-        float: 'left'
-      }}
-    >
-      <ArrowNarrowLeft size="36" />
-    </Button>
+    <Tooltip label="Show the previous page" openDelay={1000}>
+      <Button
+        data-testid="back-button"
+        aria-label="Back Button"
+        onClick={() => router.back()}
+        radius="md"
+        size="sm"
+        style={{
+          float: 'left'
+        }}
+      >
+        <ArrowNarrowLeft size="36" />
+      </Button>
+    </Tooltip>
   );
 };
 

--- a/components/PopulationCalculation.tsx
+++ b/components/PopulationCalculation.tsx
@@ -1,4 +1,4 @@
-import { Button, Center, Grid, Drawer, Group } from '@mantine/core';
+import { Button, Center, Grid, Drawer, Group, Tooltip } from '@mantine/core';
 import { useRecoilValue } from 'recoil';
 import { patientTestCaseState } from '../state/atoms/patientTestCase';
 import { measureBundleState } from '../state/atoms/measureBundle';
@@ -22,8 +22,8 @@ export default function PopulationCalculation() {
   const measurementPeriod = useRecoilValue(measurementPeriodState);
   const [measureReports, setMeasureReports] = useState<DetailedMeasureReport[]>([]);
   const [opened, setOpened] = useState(false);
-  const [showTableButton, setShowTableButton] = useState(false);
-  const [showClauseCoverageButton, setShowClauseCoverageButton] = useState(false);
+  const [enableTableButton, setEnableTableButton] = useState(false);
+  const [enableClauseCoverageButton, setEnableClauseCoverageButton] = useState(false);
   const [clauseCoverageHTML, setClauseCoverageHTML] = useState<string | null>(null);
 
   /**
@@ -91,8 +91,8 @@ export default function PopulationCalculation() {
           });
           setMeasureReports(labeledMeasureReports);
           setOpened(true);
-          setShowTableButton(true);
-          setShowClauseCoverageButton(true);
+          setEnableTableButton(true);
+          setEnableClauseCoverageButton(true);
         }
       })
       .catch(e => {
@@ -122,30 +122,42 @@ export default function PopulationCalculation() {
                 >
                   &nbsp;Calculate Population Results
                 </Button>
-                <Button
-                  data-testid="show-table-button"
-                  aria-label="Show Table"
-                  styles={{ root: { marginTop: 20 } }}
-                  hidden={!showTableButton}
-                  onClick={() => setOpened(true)}
-                  variant="default"
+                <Tooltip
+                  label="Disabled until calculation results are available"
+                  openDelay={1000}
+                  disabled={enableTableButton ? true : false}
                 >
-                  &nbsp;Show Table
-                </Button>
+                  <Button
+                    data-testid="show-table-button"
+                    aria-label="Show Table"
+                    styles={{ root: { marginTop: 20 } }}
+                    disabled={!enableTableButton}
+                    onClick={() => setOpened(true)}
+                    variant="default"
+                  >
+                    &nbsp;Show Table
+                  </Button>
+                </Tooltip>
                 <Link
                   href={{ pathname: `/${measureBundle.content.id}/coverage`, query: { clauseCoverageHTML } }}
                   key={'coverage'}
                   passHref
                 >
-                  <Button
-                    data-testid="show-coverage-button"
-                    aria-label="Show Clause Coverage"
-                    styles={{ root: { marginTop: 20 } }}
-                    hidden={!showClauseCoverageButton}
-                    variant="default"
+                  <Tooltip
+                    label="Disabled until calculation results are available"
+                    openDelay={1000}
+                    disabled={enableClauseCoverageButton ? true : false}
                   >
-                    &nbsp;Show Clause Coverage
-                  </Button>
+                    <Button
+                      data-testid="show-coverage-button"
+                      aria-label="Show Clause Coverage"
+                      styles={{ root: { marginTop: 20 } }}
+                      disabled={!enableClauseCoverageButton}
+                      variant="default"
+                    >
+                      &nbsp;Show Clause Coverage
+                    </Button>
+                  </Tooltip>
                 </Link>
               </Group>
               {measureReports.length > 0 && (

--- a/components/PopulationCalculation.tsx
+++ b/components/PopulationCalculation.tsx
@@ -10,6 +10,7 @@ import { fhirJson } from '@fhir-typescript/r4-core';
 import { measurementPeriodState } from '../state/atoms/measurementPeriod';
 import { showNotification } from '@mantine/notifications';
 import { IconAlertCircle } from '@tabler/icons';
+import Link from 'next/link';
 
 interface PatientLabel {
   [patientId: string]: string;
@@ -22,6 +23,7 @@ export default function PopulationCalculation() {
   const [measureReports, setMeasureReports] = useState<DetailedMeasureReport[]>([]);
   const [opened, setOpened] = useState(false);
   const [showTableButton, setShowTableButton] = useState(false);
+  const [showCoverageButton, setShowCoverageButton] = useState(false);
 
   /**
    * Creates object that maps patient ids to their name/DOB info strings.
@@ -84,6 +86,7 @@ export default function PopulationCalculation() {
           setMeasureReports(labeledMeasureReports);
           setOpened(true);
           setShowTableButton(true);
+          setShowCoverageButton(true);
         }
       })
       .catch(e => {
@@ -123,6 +126,18 @@ export default function PopulationCalculation() {
                 >
                   &nbsp;Show Table
                 </Button>
+                <Link href={`/${measureBundle.content.id}/coverage`} key={'coverage'} passHref>
+                  <Button
+                    data-testid="show-coverage-button"
+                    aria-label="Show Clause Coverage"
+                    styles={{ root: { marginTop: 20 } }}
+                    hidden={!showCoverageButton}
+                    onClick={() => null}
+                    variant="default"
+                  >
+                    &nbsp;Show Clause Coverage
+                  </Button>
+                </Link>
               </Group>
               {measureReports.length > 0 && (
                 <>

--- a/components/PopulationCalculation.tsx
+++ b/components/PopulationCalculation.tsx
@@ -2,7 +2,7 @@ import { Button, Center, Grid, Drawer, Group } from '@mantine/core';
 import { useRecoilValue } from 'recoil';
 import { patientTestCaseState } from '../state/atoms/patientTestCase';
 import { measureBundleState } from '../state/atoms/measureBundle';
-import { Calculator, CalculatorTypes } from 'fqm-execution';
+import { Calculator, CalculatorTypes, MeasureReportBuilder } from 'fqm-execution';
 import { createPatientBundle, getPatientInfoString } from '../util/fhir';
 import { DetailedMeasureReport, PopulationResultsViewer } from 'ecqm-visualizers';
 import { useState } from 'react';
@@ -48,6 +48,7 @@ export default function PopulationCalculation() {
     const options: CalculatorTypes.CalculationOptions = {
       calculateHTML: false,
       calculateSDEs: false,
+      calculateClauseCoverage: true,
       reportType: 'individual',
       measurementPeriodStart: measurementPeriod.start?.toISOString(),
       measurementPeriodEnd: measurementPeriod.end?.toISOString()
@@ -61,6 +62,9 @@ export default function PopulationCalculation() {
     });
 
     if (measureBundle.content) {
+      // TODO: change this so that we can access the coverage HTML???
+      const results = await Calculator.calculate(measureBundle.content, patientBundles, options);
+      const measureReports = MeasureReportBuilder.buildMeasureReports(measureBundle.content, results, options);
       const measureReports = await Calculator.calculateMeasureReports(measureBundle.content, patientBundles, options);
       return measureReports.results as fhir4.MeasureReport[];
     } else return;

--- a/components/PopulationCalculation.tsx
+++ b/components/PopulationCalculation.tsx
@@ -24,6 +24,7 @@ export default function PopulationCalculation() {
   const [opened, setOpened] = useState(false);
   const [showTableButton, setShowTableButton] = useState(false);
   const [showCoverageButton, setShowCoverageButton] = useState(false);
+  const [html, setHTML] = useState('');
 
   /**
    * Creates object that maps patient ids to their name/DOB info strings.
@@ -62,11 +63,14 @@ export default function PopulationCalculation() {
     });
 
     if (measureBundle.content) {
-      // TODO: change this so that we can access the coverage HTML???
-      const results = await Calculator.calculate(measureBundle.content, patientBundles, options);
+      const calculationResults = await Calculator.calculate(measureBundle.content, patientBundles, options);
+      const { results, coverageHTML } = calculationResults;
+      if (coverageHTML) {
+        setHTML(coverageHTML);
+      }
       const measureReports = MeasureReportBuilder.buildMeasureReports(measureBundle.content, results, options);
-      const measureReports = await Calculator.calculateMeasureReports(measureBundle.content, patientBundles, options);
-      return measureReports.results as fhir4.MeasureReport[];
+      
+      return measureReports as fhir4.MeasureReport[];
     } else return;
   };
 
@@ -130,13 +134,16 @@ export default function PopulationCalculation() {
                 >
                   &nbsp;Show Table
                 </Button>
-                <Link href={`/${measureBundle.content.id}/coverage`} key={'coverage'} passHref>
+                <Link
+                  href={{ pathname: `/${measureBundle.content.id}/coverage`, query: { html } }}
+                  key={'coverage'}
+                  passHref
+                >
                   <Button
                     data-testid="show-coverage-button"
                     aria-label="Show Clause Coverage"
                     styles={{ root: { marginTop: 20 } }}
                     hidden={!showCoverageButton}
-                    onClick={() => null}
                     variant="default"
                   >
                     &nbsp;Show Clause Coverage
@@ -155,7 +162,6 @@ export default function PopulationCalculation() {
                     size="lg"
                   >
                     <h2>Population Results</h2>
-
                     <div
                       data-testid="results-table"
                       style={{

--- a/components/PopulationCalculation.tsx
+++ b/components/PopulationCalculation.tsx
@@ -23,8 +23,8 @@ export default function PopulationCalculation() {
   const [measureReports, setMeasureReports] = useState<DetailedMeasureReport[]>([]);
   const [opened, setOpened] = useState(false);
   const [showTableButton, setShowTableButton] = useState(false);
-  const [showCoverageButton, setShowCoverageButton] = useState(false);
-  const [html, setHTML] = useState('');
+  const [showClauseCoverageButton, setShowClauseCoverageButton] = useState(false);
+  const [clauseCoverageHTML, setClauseCoverageHTML] = useState<string | null>(null);
 
   /**
    * Creates object that maps patient ids to their name/DOB info strings.
@@ -66,10 +66,9 @@ export default function PopulationCalculation() {
       const calculationResults = await Calculator.calculate(measureBundle.content, patientBundles, options);
       const { results, coverageHTML } = calculationResults;
       if (coverageHTML) {
-        setHTML(coverageHTML);
+        setClauseCoverageHTML(coverageHTML);
       }
       const measureReports = MeasureReportBuilder.buildMeasureReports(measureBundle.content, results, options);
-      
       return measureReports as fhir4.MeasureReport[];
     } else return;
   };
@@ -94,7 +93,7 @@ export default function PopulationCalculation() {
           setMeasureReports(labeledMeasureReports);
           setOpened(true);
           setShowTableButton(true);
-          setShowCoverageButton(true);
+          setShowClauseCoverageButton(true);
         }
       })
       .catch(e => {
@@ -135,7 +134,7 @@ export default function PopulationCalculation() {
                   &nbsp;Show Table
                 </Button>
                 <Link
-                  href={{ pathname: `/${measureBundle.content.id}/coverage`, query: { html } }}
+                  href={{ pathname: `/${measureBundle.content.id}/coverage`, query: { clauseCoverageHTML } }}
                   key={'coverage'}
                   passHref
                 >
@@ -143,7 +142,7 @@ export default function PopulationCalculation() {
                     data-testid="show-coverage-button"
                     aria-label="Show Clause Coverage"
                     styles={{ root: { marginTop: 20 } }}
-                    hidden={!showCoverageButton}
+                    hidden={!showClauseCoverageButton}
                     variant="default"
                   >
                     &nbsp;Show Clause Coverage

--- a/components/PopulationCalculation.tsx
+++ b/components/PopulationCalculation.tsx
@@ -63,8 +63,7 @@ export default function PopulationCalculation() {
     });
 
     if (measureBundle.content) {
-      const calculationResults = await Calculator.calculate(measureBundle.content, patientBundles, options);
-      const { results, coverageHTML } = calculationResults;
+      const { results, coverageHTML } = await Calculator.calculate(measureBundle.content, patientBundles, options);
       if (coverageHTML) {
         setClauseCoverageHTML(coverageHTML);
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3579,8 +3579,9 @@
       }
     },
     "fqm-execution": {
-      "version": "git+ssh://git@github.com/projecttacoma/fqm-execution.git#99e5445f60b17e53c07b6bbeed6f91ce5ebda6e3",
-      "from": "git+ssh://git@github.com/projecttacoma/fqm-execution.git",
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/fqm-execution/-/fqm-execution-1.0.0-beta.3.tgz",
+      "integrity": "sha512-Pz71DjWtqVr9ymltbwRKzXALz3lwH2v/19pDICSIOXbUh2nVimnG7Chv7bqZ4KFAxfX3JuxH/oFsrwpWMcjN8A==",
       "requires": {
         "@types/fhir": "0.0.34",
         "atob": "^2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3037,7 +3037,7 @@
         "type-check": {
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-          "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+          "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
           "dev": true,
           "requires": {
             "prelude-ls": "~1.1.2"
@@ -6259,7 +6259,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "uuid": {
       "version": "8.3.2",
@@ -6407,7 +6407,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
     "write-file-atomic": {
@@ -6455,7 +6455,7 @@
     "xmldoc": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/xmldoc/-/xmldoc-0.4.0.tgz",
-      "integrity": "sha1-0lciS+g5PqrL+DfvIn/Y7CWzaIg=",
+      "integrity": "sha512-rJ/+/UzYCSlFNuAzGuRyYgkH2G5agdX1UQn4+5siYw9pkNC3Hu/grYNDx/dqYLreeSjnY5oKg74CMBKxJHSg6Q==",
       "requires": {
         "sax": "~1.1.1"
       },
@@ -6470,7 +6470,7 @@
     "xtend": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-      "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+      "integrity": "sha512-vMNKzr2rHP9Dp/e1NQFnLQlwlhp9L/LfvnsVdHxN1f+uggyVI3i08uD14GPvCToPkdsRfyPqIyYGmIk58V98ZQ==",
       "requires": {
         "object-keys": "~0.4.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2501,7 +2501,7 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "cql-exec-fhir": {
-      "version": "github:projecttacoma/cql-exec-fhir#45a03f62c8af2905e562b8b1d4919725d585ce25",
+      "version": "github:projecttacoma/cql-exec-fhir#d48d57c3c7e199cbaa02e41418cad9efcd148b15",
       "from": "github:projecttacoma/cql-exec-fhir",
       "requires": {
         "@babel/runtime": "^7.17.2",
@@ -3563,9 +3563,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
-      "integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ=="
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA=="
     },
     "form-data": {
       "version": "4.0.0",
@@ -3579,9 +3579,8 @@
       }
     },
     "fqm-execution": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/fqm-execution/-/fqm-execution-1.0.0-beta.2.tgz",
-      "integrity": "sha512-wXgv+IBKTgGire+WteQ3JIfEIZaT1rp/cHEjPHRtzjTu0B1Y1WD6Cdx+uSgEhTgPCF8Kjki7V9CsV/ySndSLpA==",
+      "version": "git+ssh://git@github.com/projecttacoma/fqm-execution.git#99e5445f60b17e53c07b6bbeed6f91ce5ebda6e3",
+      "from": "git+ssh://git@github.com/projecttacoma/fqm-execution.git",
       "requires": {
         "@types/fhir": "0.0.34",
         "atob": "^2.1.2",
@@ -3591,7 +3590,7 @@
         "cql-execution": "github:projecttacoma/cql-execution",
         "handlebars": "^4.7.7",
         "lodash": "^4.17.21",
-        "moment": "^2.29.3",
+        "moment": "^2.29.4",
         "uuid": "^8.3.1"
       }
     },
@@ -6207,9 +6206,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.15.5",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.5.tgz",
-      "integrity": "sha512-hNM5q5GbBRB5xB+PMqVRcgYe4c8jbyZ1pzZhS6jbq54/4F2gFK869ZheiE5A8/t+W5jtTNpWef/5Q9zk639FNQ==",
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.0.tgz",
+      "integrity": "sha512-aTeNPVmgIMPpm1cxXr2Q/nEbvkmV8yq66F3om7X3P/cvOXQ0TMQ64Wk63iyT1gPlmdmGzjGpyLh1f3y8MZWXGg==",
       "optional": true
     },
     "unbox-primitive": {
@@ -6392,7 +6391,7 @@
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
     },
     "wrap-ansi": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "ecqm-visualizers": "0.0.1",
     "fhirpath": "^2.14.6",
     "file-saver": "^2.0.5",
-    "fqm-execution": "git+ssh://github.com/projecttacoma/fqm-execution.git",
+    "fqm-execution": "^1.0.0-beta.3",
     "fuse.js": "^6.6.2",
     "immer": "^9.0.14",
     "jszip": "^3.10.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "ecqm-visualizers": "0.0.1",
     "fhirpath": "^2.14.6",
     "file-saver": "^2.0.5",
-    "fqm-execution": "^1.0.0-beta.2",
+    "fqm-execution": "git@github.com:projecttacoma/fqm-execution",
     "fuse.js": "^6.6.2",
     "immer": "^9.0.14",
     "jszip": "^3.10.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "ecqm-visualizers": "0.0.1",
     "fhirpath": "^2.14.6",
     "file-saver": "^2.0.5",
-    "fqm-execution": "git@github.com:projecttacoma/fqm-execution",
+    "fqm-execution": "git+ssh://github.com/projecttacoma/fqm-execution.git",
     "fuse.js": "^6.6.2",
     "immer": "^9.0.14",
     "jszip": "^3.10.0",

--- a/pages/[measureId]/coverage.tsx
+++ b/pages/[measureId]/coverage.tsx
@@ -14,13 +14,13 @@ const useStyles = createStyles(() => ({
 const ClauseCoveragePage = () => {
   const { classes } = useStyles();
   const router = useRouter();
-  const { html, measureId } = router.query;
-  if (typeof html === 'string') {
+  const { clauseCoverageHTML, measureId } = router.query;
+  if (typeof clauseCoverageHTML === 'string' && clauseCoverageHTML.length > 0) {
     return (
       <>
         <Group>
           <BackButton />
-          <h2>Clause coverage for measure: {`${measureId}`}</h2>
+          <h2>Clause coverage for measure bundle: {`${measureId}`}</h2>
         </Group>
         <Center>
           <div
@@ -30,12 +30,19 @@ const ClauseCoveragePage = () => {
               overflow: 'scroll'
             }}
           >
-            {parse(html)}
+            {parse(clauseCoverageHTML)}
           </div>
         </Center>
       </>
     );
-  } else return (<div></div>);
+  } else return (
+    <>
+    <Group>
+      <BackButton />
+      <h2>No clause coverage results available for measure bundle: {`${measureId}`} </h2>
+    </Group>
+    </>
+  );
 };
 
 export default ClauseCoveragePage;

--- a/pages/[measureId]/coverage.tsx
+++ b/pages/[measureId]/coverage.tsx
@@ -18,7 +18,7 @@ const ClauseCoveragePage = () => {
   if (typeof clauseCoverageHTML === 'string' && clauseCoverageHTML.length > 0) {
     return (
       <>
-        <Group style={{ outlineColor: '2px' }}>
+        <Group>
           <BackButton />
           <h2>Clause coverage for measure bundle: {`${measureId}`}</h2>
         </Group>
@@ -26,8 +26,9 @@ const ClauseCoveragePage = () => {
           <div
             className={classes.highlightedMarkup}
             style={{
-              maxHeight: '55vh',
-              overflow: 'scroll'
+              maxHeight: '90vh',
+              overflow: 'scroll',
+              marginLeft: '5px'
             }}
           >
             {parse(clauseCoverageHTML)}

--- a/pages/[measureId]/coverage.tsx
+++ b/pages/[measureId]/coverage.tsx
@@ -18,7 +18,7 @@ const ClauseCoveragePage = () => {
   if (typeof clauseCoverageHTML === 'string' && clauseCoverageHTML.length > 0) {
     return (
       <>
-        <Group>
+        <Group style={{ outlineColor: '2px' }}>
           <BackButton />
           <h2>Clause coverage for measure bundle: {`${measureId}`}</h2>
         </Group>
@@ -35,14 +35,15 @@ const ClauseCoveragePage = () => {
         </Center>
       </>
     );
-  } else return (
-    <>
-    <Group>
-      <BackButton />
-      <h2>No clause coverage results available for measure bundle: {`${measureId}`} </h2>
-    </Group>
-    </>
-  );
+  } else
+    return (
+      <>
+        <Group>
+          <BackButton />
+          <h2>No clause coverage results available for measure bundle: {`${measureId}`} </h2>
+        </Group>
+      </>
+    );
 };
 
 export default ClauseCoveragePage;

--- a/pages/[measureId]/coverage.tsx
+++ b/pages/[measureId]/coverage.tsx
@@ -1,0 +1,18 @@
+import { Center } from '@mantine/core';
+import { useRouter } from 'next/router';
+import BackButton from '../../components/BackButton';
+
+const ClauseCoveragePage = () => {
+  const router = useRouter();
+  const { measureId } = router.query;
+  return (
+    <div>
+      <BackButton />
+      <Center>
+        <h2>Clause coverage for measure: {`${measureId}`}</h2>
+      </Center>
+    </div>
+  );
+};
+
+export default ClauseCoveragePage;

--- a/pages/[measureId]/coverage.tsx
+++ b/pages/[measureId]/coverage.tsx
@@ -1,18 +1,41 @@
-import { Center } from '@mantine/core';
+import { Center, createStyles, Group } from '@mantine/core';
 import { useRouter } from 'next/router';
 import BackButton from '../../components/BackButton';
+import parse from 'html-react-parser';
+
+const useStyles = createStyles(() => ({
+  highlightedMarkup: {
+    '& pre': {
+      whiteSpace: 'pre-wrap'
+    }
+  }
+}));
 
 const ClauseCoveragePage = () => {
+  const { classes } = useStyles();
   const router = useRouter();
-  const { measureId } = router.query;
-  return (
-    <div>
-      <BackButton />
-      <Center>
-        <h2>Clause coverage for measure: {`${measureId}`}</h2>
-      </Center>
-    </div>
-  );
+  const { html, measureId } = router.query;
+  if (typeof html === 'string') {
+    return (
+      <>
+        <Group>
+          <BackButton />
+          <h2>Clause coverage for measure: {`${measureId}`}</h2>
+        </Group>
+        <Center>
+          <div
+            className={classes.highlightedMarkup}
+            style={{
+              maxHeight: '55vh',
+              overflow: 'scroll'
+            }}
+          >
+            {parse(html)}
+          </div>
+        </Center>
+      </>
+    );
+  } else return (<div></div>);
 };
 
 export default ClauseCoveragePage;


### PR DESCRIPTION
# Summary
Adds a button and new page to show the clause coverage HTML after running population calculation.

## New behavior
After the user clicks on the “Calculate Population Results” button and the calculation has finished, a new button will appear with the text “See Clause Coverage.” When clicked, the user will be brought to a new page that shows the clause coverage HTML and the clause coverage percentage. When finished viewing the HTML, the user can click the back button to return to the main page.

## Code changes
* `BackButton` component that takes the user back to the previous page
* `PopulationCalculation` component changes
    * Set `calculateClauseCoverage` to `true` within the calculation options so that we can retrieve the clause coverage HTML from the fqm-execution results
    * New button that appears on successful calculation that links to the new `[measureid]/coverage.tsx` page and passes the clause coverage HTML to the new page
* New helper in `testHelpers.tsx` for creating the mock router used to test routing to the new page
* Unit tests for coverage page, and updated unit tests for population calculation coverage button

# Testing Guidance
**NOTE: the fqm-execution path was changed in `package.json` to get access to the coverage HTML code**. We need to include the clause coverage updates in the latest npm release of fqm-execution.
When testing, make sure to run `npm install` to get the clause coverage changes from fqm-execution. Then, try running `npm run check` to check that the unit tests, lint, and prettier all pass. Try running `npm ci` and check that it executes successfully.

Run the unit tests that test the functionality of the new route and clause coverage HTML rendering.

Try navigating to the clause coverage page in the app by doing the following:
* Upload a measure, select the appropriate measurement period, and import/create test cases
* Click on “Calculate Population Results”
* Check for a new button to appear that says “Show Clause Coverage,” then click on it
* You should be brought to the new page. Check that the clause coverage HTML gets rendered, and that all the necessary information is available for the user (the measure id, clause coverage percentage, etc. Let me know if you think anything else should be on the page, like the patient names used in the calculation or any other information from the calculation)
* Run through the process again, but try adding/removing patients for certain populations. You should see the highlighted clauses change, and the percentage should change as well (for example, running calculation with just denominator patients versus running calculation with both numerator and denominator patients)
