### PR TITLE
Element reference codes

### DIFF
--- a/__tests__/utils/fhir.test.ts
+++ b/__tests__/utils/fhir.test.ts
@@ -429,7 +429,6 @@ describe('createFHIRResourceString', () => {
       PERIOD_START,
       PERIOD_END
     );
-    console.log(createdResource);
     expect(Array.isArray(JSON.parse(createdResource).topic)).toBe(true);
     expect(JSON.parse(createdResource).subject).toBeUndefined();
   });

--- a/__tests__/utils/fhir.test.ts
+++ b/__tests__/utils/fhir.test.ts
@@ -25,11 +25,33 @@ const PERIOD_START = '2020-01-01T00:00:00.000Z';
 const PERIOD_END = '2020-12-31T00:00:00.000Z';
 
 const VS_MAP = { testvs: 'test vs name' };
-const DATA_REQUIREMENT_WITH_NO_VALUE_SETS = {
+
+// data requirement that does not have any valuesets or any direct reference codes
+const DATA_REQUIREMENT_WITH_NO_VALUESETS_OR_DRC = {
   type: 'Observation',
   status: 'draft'
 };
-const DATA_REQUIREMENT_WITH_VALUE_SETS = {
+
+// data requirement that does not have any valuesets but has a direct reference code
+const DATA_REQUIREMENT_WITH_NO_VALUESETS_WITH_DRC = {
+  type: 'Communication',
+  status: 'draft',
+  codeFilter: [
+    {
+      path: 'reasonCode',
+      code: [
+        {
+          system: 'http://snomed.info/sct/731000124108',
+          version: 'http://snomed.info/sct/731000124108/version/201709',
+          display: 'test display 2',
+          code: '456'
+        }
+      ]
+    }
+  ]
+};
+
+const DATA_REQUIREMENT_WITH_VALUESETS = {
   type: 'Observation',
   status: 'draft',
   codeFilter: [
@@ -58,7 +80,7 @@ const DATA_REQUIREMENT_WITH_CODE = {
   ]
 };
 
-// example data requirement for resource type with primaryCodeType FHIR.CodeableConcept
+// example data requirement for resource type with primaryCodeType FHIR.CodeableConcept and valueset
 const OBSERVATION_DATA_REQUIREMENT_WITH_CODE_AND_VALUESET = {
   type: 'Observation',
   status: 'draft',
@@ -68,7 +90,7 @@ const OBSERVATION_DATA_REQUIREMENT_WITH_CODE_AND_VALUESET = {
       valueSet: 'testvs'
     },
     {
-      path: 'code',
+      path: 'category',
       code: [
         {
           system: 'http://snomed.info/sct/731000124108',
@@ -87,7 +109,7 @@ const MESSAGEDEFINITION_DATA_REQUIREMENT = {
   status: 'draft',
   codeFilter: [
     {
-      path: 'code',
+      path: 'event',
       valueSet: 'testvs'
     }
   ]
@@ -111,7 +133,7 @@ const ACTIVITYDEFINITION_DATA_REQUIREMENT = {
   status: 'draft',
   codeFilter: [
     {
-      path: 'code',
+      path: 'topic',
       valueSet: 'testvs'
     }
   ]
@@ -297,18 +319,23 @@ const EXAMPLE_FIELD_CHOICE_TYPE_DATE: dateFieldInfo = {
 const EXAMPLE_PATH = 'testPath';
 
 describe('getDataRequirementFiltersString', () => {
-  test('returns an empty string for resource with no valuesets', () => {
-    expect(getDataRequirementFiltersString(DATA_REQUIREMENT_WITH_NO_VALUE_SETS, VS_MAP)).toEqual('');
+  test('returns an empty string for resource with no valuesets and no direct reference code', () => {
+    expect(getDataRequirementFiltersString(DATA_REQUIREMENT_WITH_NO_VALUESETS_OR_DRC, VS_MAP)).toEqual('');
+  });
+  test('returns name of code and display when there is a direct reference code but no valuesets', () => {
+    expect(getDataRequirementFiltersString(DATA_REQUIREMENT_WITH_NO_VALUESETS_WITH_DRC, VS_MAP)).toEqual(
+      '456: test display 2'
+    );
   });
   test('returns name of valueset when codefilter includes valueset', () => {
-    expect(getDataRequirementFiltersString(DATA_REQUIREMENT_WITH_VALUE_SETS, VS_MAP)).toEqual('test vs name (testvs)');
+    expect(getDataRequirementFiltersString(DATA_REQUIREMENT_WITH_VALUESETS, VS_MAP)).toEqual('test vs name (testvs)');
   });
   test('returns display when code filter is of path code', () => {
-    expect(getDataRequirementFiltersString(DATA_REQUIREMENT_WITH_CODE, VS_MAP)).toEqual('test display');
+    expect(getDataRequirementFiltersString(DATA_REQUIREMENT_WITH_CODE, VS_MAP)).toEqual('37687000: test display');
   });
   test('returns display and name when both code and valueset exist', () => {
     expect(getDataRequirementFiltersString(OBSERVATION_DATA_REQUIREMENT_WITH_CODE_AND_VALUESET, VS_MAP)).toEqual(
-      'test vs name (testvs)\ntest display'
+      'test vs name (testvs)\n37687000: test display'
     );
   });
 });
@@ -394,7 +421,7 @@ describe('createFHIRResourceString', () => {
     expect(JSON.parse(createdResource).subject).toBeUndefined();
   });
 
-  test('returns populated FHIR resource where primaryCodePath us 0..* or 1..* (multiple cardinality)', () => {
+  test('returns populated FHIR resource where primaryCodePath is 0..* or 1..* (multiple cardinality)', () => {
     const createdResource = createFHIRResourceString(
       ACTIVITYDEFINITION_DATA_REQUIREMENT,
       TEST_MEASURE_BUNDLE,
@@ -402,6 +429,7 @@ describe('createFHIRResourceString', () => {
       PERIOD_START,
       PERIOD_END
     );
+    console.log(createdResource);
     expect(Array.isArray(JSON.parse(createdResource).topic)).toBe(true);
     expect(JSON.parse(createdResource).subject).toBeUndefined();
   });

--- a/__tests__/utils/fhir.test.ts
+++ b/__tests__/utils/fhir.test.ts
@@ -139,6 +139,24 @@ const ACTIVITYDEFINITION_DATA_REQUIREMENT = {
   ]
 };
 
+const DATA_REQUIREMENT_WITH_CHOICETYPE_CODEABLE_CONCEPT = {
+  type: 'DeviceRequest',
+  status: 'draft',
+  codeFilter: [
+    {
+      path: 'code',
+      code: [
+        {
+          system: 'http://snomed.info/sct/731000124108',
+          version: 'http://snomed.info/sct/731000124108/version/201709',
+          display: 'test display',
+          code: '37687000'
+        }
+      ]
+    }
+  ]
+};
+
 // example data requirement for resource type with `subject` not used as the patient reference
 const COVERAGE_DATA_REQUIREMENT = {
   type: 'Coverage',
@@ -400,7 +418,7 @@ describe('createFHIRResourceString', () => {
       PERIOD_START,
       PERIOD_END
     );
-    expect(JSON.parse(createdResource).event).toEqual({
+    expect(JSON.parse(createdResource).eventCoding).toEqual({
       system: 'test-system',
       version: 'test-version',
       code: '123',
@@ -409,7 +427,7 @@ describe('createFHIRResourceString', () => {
     expect(JSON.parse(createdResource).subject).toBeUndefined();
   });
 
-  test('returns populated FHIR resource for primaryCodeType FHIR.code', () => {
+  test('returns populated FHIR resource for codeType FHIR.code', () => {
     const createdResource = createFHIRResourceString(
       OPERATIONDEFINITION_DATA_REQUIREMENT,
       TEST_MEASURE_BUNDLE,
@@ -419,6 +437,26 @@ describe('createFHIRResourceString', () => {
     );
     expect(JSON.parse(createdResource).code).toEqual('123');
     expect(JSON.parse(createdResource).subject).toBeUndefined();
+  });
+
+  test('returns populated FHIR resource for choiceType codeable concept', () => {
+    const createdResource = createFHIRResourceString(
+      DATA_REQUIREMENT_WITH_CHOICETYPE_CODEABLE_CONCEPT,
+      TEST_MEASURE_BUNDLE,
+      'Patient1',
+      PERIOD_START,
+      PERIOD_END
+    );
+    expect(JSON.parse(createdResource).codeCodeableConcept).toEqual({
+      coding: [
+        {
+          system: 'http://snomed.info/sct/731000124108',
+          version: 'http://snomed.info/sct/731000124108/version/201709',
+          code: '37687000',
+          display: 'test display'
+        }
+      ]
+    });
   });
 
   test('returns populated FHIR resource where primaryCodePath is 0..* or 1..* (multiple cardinality)', () => {

--- a/scripts/parseCodePath.ts
+++ b/scripts/parseCodePath.ts
@@ -26,7 +26,7 @@ interface elementChoice {
 export async function parse(xml: string) {
   const { modelInfo } = await xml2js.parseStringPromise(xml);
   const domainInfo = modelInfo.typeInfo.filter((ti: any) => ti.$.baseType === 'FHIR.DomainResource');
-  const elementInfo = modelInfo.typeInfo.filter((ti: any) => ti.$.baseType == 'FHIR.Element');
+  const elementInfo = modelInfo.typeInfo.filter((ti: any) => ti.$.baseType == 'FHIR.Element' && !ti.$.identifier);
   const elementOneValue = elementInfo.filter((e: any) => e.element.length === 1);
 
   const results: { [key: string]: ResourceCodeInfo } = {};
@@ -91,6 +91,7 @@ export async function parse(xml: string) {
         // add elements of these three types to the paths of that resource
         if (codeType === 'FHIR.CodeableConcept' || codeType === 'FHIR.Coding' || codeType === 'FHIR.code') {
           paths[elem.$.name] = { codeType, multipleCardinality, choiceType };
+          codeType = '';
         } else if (codeType && codeType !== 'FHIR.string') {
           // if the codeType is not one of those three but also not a FHIR.string it may be within a FHIR.Element
           const codeTypeName = codeType.split('R.');
@@ -99,6 +100,7 @@ export async function parse(xml: string) {
             if (name[0].element[0].$.elementType === 'System.String') {
               codeType = 'FHIR.code';
               paths[elem.$.name] = { codeType, multipleCardinality, choiceType };
+              codeType = '';
             }
           }
         }

--- a/scripts/parseCodePath.ts
+++ b/scripts/parseCodePath.ts
@@ -26,7 +26,7 @@ interface elementChoice {
 export async function parse(xml: string) {
   const { modelInfo } = await xml2js.parseStringPromise(xml);
   const domainInfo = modelInfo.typeInfo.filter((ti: any) => ti.$.baseType === 'FHIR.DomainResource');
-  const elementInfo = modelInfo.typeInfo.filter((ti: any) => ti.$.baseType == 'FHIR.Element' && !ti.$.identifier);
+  const elementInfo = modelInfo.typeInfo.filter((ti: any) => ti.$.baseType === 'FHIR.Element' && !ti.$.identifier);
   const elementOneValue = elementInfo.filter((e: any) => e.element.length === 1);
 
   const results: { [key: string]: ResourceCodeInfo } = {};

--- a/scripts/parseCodePath.ts
+++ b/scripts/parseCodePath.ts
@@ -27,7 +27,7 @@ export async function parse(xml: string) {
   const { modelInfo } = await xml2js.parseStringPromise(xml);
   const domainInfo = modelInfo.typeInfo.filter((ti: any) => ti.$.baseType === 'FHIR.DomainResource');
   const elementInfo = modelInfo.typeInfo.filter((ti: any) => ti.$.baseType == 'FHIR.Element');
-  const systemString = elementInfo.filter((e: any) => e.element.length === 1);
+  const elementOneValue = elementInfo.filter((e: any) => e.element.length === 1);
 
   const results: { [key: string]: ResourceCodeInfo } = {};
 
@@ -42,6 +42,7 @@ export async function parse(xml: string) {
       let multipleCardinality: boolean;
       let choiceType: boolean;
 
+      // go through every element in the domainInfo
       di.element.forEach((elem: any) => {
         if (elem.elementTypeSpecifier) {
           // length of element.elementTypeSpecifier is always 1, so we can index it at 0
@@ -87,11 +88,13 @@ export async function parse(xml: string) {
           // indicate that this is not a choice type
           choiceType = false;
         }
+        // add elements of these three types to the paths of that resource
         if (codeType === 'FHIR.CodeableConcept' || codeType === 'FHIR.Coding' || codeType === 'FHIR.code') {
           paths[elem.$.name] = { codeType, multipleCardinality, choiceType };
         } else if (codeType && codeType !== 'FHIR.string') {
-          let codeTypeName = codeType.split('R.');
-          const name = systemString.filter((e: any) => e.$.name === codeTypeName[1]);
+          // if the codeType is not one of those three but also not a FHIR.string it may be within a FHIR.Element
+          const codeTypeName = codeType.split('R.');
+          const name = elementOneValue.filter((e: any) => e.$.name === codeTypeName[1]);
           if (name.length === 1) {
             if (name[0].element[0].$.elementType === 'System.String') {
               codeType = 'FHIR.code';

--- a/util/codePaths.ts
+++ b/util/codePaths.ts
@@ -4,6 +4,11 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   Account: {
     primaryCodePath: 'type',
     paths: {
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       type: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: false,
@@ -14,6 +19,16 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   ActivityDefinition: {
     primaryCodePath: 'topic',
     paths: {
+      url: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       subject: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: false,
@@ -29,8 +44,23 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
         multipleCardinality: true,
         choiceType: false
       },
+      kind: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       code: {
         codeType: 'FHIR.CodeableConcept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      intent: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      priority: {
+        codeType: 'FHIR.code',
         multipleCardinality: false,
         choiceType: false
       },
@@ -49,6 +79,11 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   AdverseEvent: {
     primaryCodePath: 'event',
     paths: {
+      actuality: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       category: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: true,
@@ -89,6 +124,21 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
         multipleCardinality: false,
         choiceType: false
       },
+      type: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      category: {
+        codeType: 'FHIR.code',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      criticality: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       code: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: false,
@@ -99,6 +149,11 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   Appointment: {
     primaryCodePath: 'serviceType',
     paths: {
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       cancelationReason: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: false,
@@ -164,6 +219,21 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   CarePlan: {
     primaryCodePath: 'category',
     paths: {
+      instantiatesUri: {
+        codeType: 'FHIR.code',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      intent: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       category: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: true,
@@ -174,6 +244,11 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   CareTeam: {
     primaryCodePath: 'category',
     paths: {
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       category: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: true,
@@ -189,6 +264,16 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   ChargeItem: {
     primaryCodePath: 'code',
     paths: {
+      definitionUri: {
+        codeType: 'FHIR.code',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       code: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: false,
@@ -214,6 +299,21 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   ChargeItemDefinition: {
     primaryCodePath: 'code',
     paths: {
+      url: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      derivedFromUri: {
+        codeType: 'FHIR.code',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       jurisdiction: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: true,
@@ -229,6 +329,11 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   Claim: {
     primaryCodePath: 'type',
     paths: {
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       type: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: false,
@@ -236,6 +341,11 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
       },
       subType: {
         codeType: 'FHIR.CodeableConcept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      use: {
+        codeType: 'FHIR.code',
         multipleCardinality: false,
         choiceType: false
       },
@@ -254,6 +364,11 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   ClinicalImpression: {
     primaryCodePath: 'code',
     paths: {
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       statusReason: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: false,
@@ -262,6 +377,11 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
       code: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: false,
+        choiceType: false
+      },
+      protocol: {
+        codeType: 'FHIR.code',
+        multipleCardinality: true,
         choiceType: false
       },
       prognosisCodeableConcept: {
@@ -274,6 +394,16 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   Communication: {
     primaryCodePath: 'category',
     paths: {
+      instantiatesUri: {
+        codeType: 'FHIR.code',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       statusReason: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: false,
@@ -282,6 +412,11 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
       category: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: true,
+        choiceType: false
+      },
+      priority: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
         choiceType: false
       },
       medium: {
@@ -304,6 +439,11 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   CommunicationRequest: {
     primaryCodePath: 'category',
     paths: {
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       statusReason: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: false,
@@ -312,6 +452,11 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
       category: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: true,
+        choiceType: false
+      },
+      priority: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
         choiceType: false
       },
       medium: {
@@ -329,6 +474,11 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   Composition: {
     primaryCodePath: 'type',
     paths: {
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       type: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: false,
@@ -337,6 +487,11 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
       category: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: true,
+        choiceType: false
+      },
+      confidentiality: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
         choiceType: false
       }
     }
@@ -379,6 +534,11 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   Consent: {
     primaryCodePath: 'category',
     paths: {
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       scope: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: false,
@@ -399,6 +559,11 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   Coverage: {
     primaryCodePath: 'type',
     paths: {
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       type: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: false,
@@ -414,8 +579,23 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   DetectedIssue: {
     primaryCodePath: 'code',
     paths: {
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       code: {
         codeType: 'FHIR.CodeableConcept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      severity: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      reference: {
+        codeType: 'FHIR.code',
         multipleCardinality: false,
         choiceType: false
       }
@@ -424,6 +604,11 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   Device: {
     primaryCodePath: 'type',
     paths: {
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       statusReason: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: true,
@@ -431,6 +616,11 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
       },
       type: {
         codeType: 'FHIR.CodeableConcept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      url: {
+        codeType: 'FHIR.code',
         multipleCardinality: false,
         choiceType: false
       },
@@ -453,12 +643,47 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: false,
         choiceType: false
+      },
+      operationalStatus: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      color: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      category: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
       }
     }
   },
   DeviceRequest: {
     primaryCodePath: 'code',
     paths: {
+      instantiatesUri: {
+        codeType: 'FHIR.code',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      intent: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      priority: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       code: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: false,
@@ -479,6 +704,11 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   DeviceUseStatement: {
     primaryCodePath: 'device.code',
     paths: {
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       reasonCode: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: true,
@@ -494,6 +724,11 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   DiagnosticReport: {
     primaryCodePath: 'code',
     paths: {
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       category: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: true,
@@ -514,6 +749,11 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   Encounter: {
     primaryCodePath: 'type',
     paths: {
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       class: {
         codeType: 'FHIR.Coding',
         multipleCardinality: false,
@@ -544,6 +784,11 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   EpisodeOfCare: {
     primaryCodePath: 'type',
     paths: {
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       type: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: true,
@@ -554,6 +799,11 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   ExplanationOfBenefit: {
     primaryCodePath: 'type',
     paths: {
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       type: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: false,
@@ -561,6 +811,11 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
       },
       subType: {
         codeType: 'FHIR.CodeableConcept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      use: {
+        codeType: 'FHIR.code',
         multipleCardinality: false,
         choiceType: false
       },
@@ -579,6 +834,11 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
         multipleCardinality: false,
         choiceType: false
       },
+      outcome: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       formCode: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: false,
@@ -589,6 +849,11 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   Flag: {
     primaryCodePath: 'code',
     paths: {
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       category: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: true,
@@ -604,6 +869,11 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   Goal: {
     primaryCodePath: 'category',
     paths: {
+      lifecycleStatus: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       achievementStatus: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: false,
@@ -639,6 +909,11 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   Group: {
     primaryCodePath: 'code',
     paths: {
+      type: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       code: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: false,
@@ -653,6 +928,11 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: false,
         choiceType: true
+      },
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
       },
       reasonCode: {
         codeType: 'FHIR.CodeableConcept',
@@ -709,6 +989,11 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   Immunization: {
     primaryCodePath: 'vaccineCode',
     paths: {
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       statusReason: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: false,
@@ -759,6 +1044,16 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   Library: {
     primaryCodePath: 'topic',
     paths: {
+      url: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       type: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: false,
@@ -784,6 +1079,16 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   List: {
     primaryCodePath: 'code',
     paths: {
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      mode: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       code: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: false,
@@ -804,8 +1109,18 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   Location: {
     primaryCodePath: 'type',
     paths: {
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       operationalStatus: {
         codeType: 'FHIR.Coding',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      mode: {
+        codeType: 'FHIR.code',
         multipleCardinality: false,
         choiceType: false
       },
@@ -824,6 +1139,16 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   Measure: {
     primaryCodePath: 'topic',
     paths: {
+      url: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       subject: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: false,
@@ -864,6 +1189,16 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   MeasureReport: {
     primaryCodePath: 'measure.topic',
     paths: {
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      type: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       improvementNotation: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: false,
@@ -879,6 +1214,11 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
         multipleCardinality: false,
         choiceType: false
       },
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       form: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: false,
@@ -889,6 +1229,16 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   MedicationAdministration: {
     primaryCodePath: 'medication',
     paths: {
+      instantiates: {
+        codeType: 'FHIR.code',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       statusReason: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: true,
@@ -914,6 +1264,11 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   MedicationDispense: {
     primaryCodePath: 'medication',
     paths: {
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       statusReason: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: false,
@@ -944,6 +1299,11 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
         multipleCardinality: false,
         choiceType: false
       },
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       doseForm: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: false,
@@ -964,14 +1324,29 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   MedicationRequest: {
     primaryCodePath: 'medication',
     paths: {
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       statusReason: {
         codeType: 'FHIR.CodeableConcept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      intent: {
+        codeType: 'FHIR.code',
         multipleCardinality: false,
         choiceType: false
       },
       category: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: true,
+        choiceType: false
+      },
+      priority: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
         choiceType: false
       },
       medication: {
@@ -989,6 +1364,11 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
         multipleCardinality: true,
         choiceType: false
       },
+      instantiatesUri: {
+        codeType: 'FHIR.code',
+        multipleCardinality: true,
+        choiceType: false
+      },
       courseOfTherapyType: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: false,
@@ -999,6 +1379,11 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   MedicationStatement: {
     primaryCodePath: 'medication',
     paths: {
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       statusReason: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: true,
@@ -1024,6 +1409,16 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   MessageDefinition: {
     primaryCodePath: 'event',
     paths: {
+      url: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       jurisdiction: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: true,
@@ -1033,12 +1428,27 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
         codeType: 'FHIR.Coding',
         multipleCardinality: false,
         choiceType: true
+      },
+      category: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      responseRequired: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
       }
     }
   },
   Observation: {
     primaryCodePath: 'code',
     paths: {
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       category: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: true,
@@ -1089,6 +1499,11 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
         multipleCardinality: false,
         choiceType: false
       },
+      permittedDataType: {
+        codeType: 'FHIR.code',
+        multipleCardinality: true,
+        choiceType: false
+      },
       method: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: false,
@@ -1099,6 +1514,21 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   OperationDefinition: {
     primaryCodePath: 'code',
     paths: {
+      url: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      kind: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       jurisdiction: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: true,
@@ -1107,6 +1537,11 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
       code: {
         codeType: 'FHIR.code',
         multipleCardinality: false,
+        choiceType: false
+      },
+      resource: {
+        codeType: 'FHIR.code',
+        multipleCardinality: true,
         choiceType: false
       }
     }
@@ -1133,6 +1568,16 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   Procedure: {
     primaryCodePath: 'code',
     paths: {
+      instantiatesUri: {
+        codeType: 'FHIR.code',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       statusReason: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: false,
@@ -1183,6 +1628,21 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   Questionnaire: {
     primaryCodePath: 'name',
     paths: {
+      url: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      subjectType: {
+        codeType: 'FHIR.code',
+        multipleCardinality: true,
+        choiceType: false
+      },
       jurisdiction: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: true,
@@ -1202,12 +1662,37 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: true,
         choiceType: false
+      },
+      gender: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
       }
     }
   },
   RequestGroup: {
     primaryCodePath: 'code',
     paths: {
+      instantiatesUri: {
+        codeType: 'FHIR.code',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      intent: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      priority: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       code: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: false,
@@ -1223,6 +1708,11 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   RiskAssessment: {
     primaryCodePath: 'code',
     paths: {
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       method: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: false,
@@ -1243,6 +1733,16 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   SearchParameter: {
     primaryCodePath: 'target',
     paths: {
+      url: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       jurisdiction: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: true,
@@ -1252,15 +1752,65 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
         codeType: 'FHIR.code',
         multipleCardinality: false,
         choiceType: false
+      },
+      base: {
+        codeType: 'FHIR.code',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      type: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      xpathUsage: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      target: {
+        codeType: 'FHIR.code',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      comparator: {
+        codeType: 'FHIR.code',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      modifier: {
+        codeType: 'FHIR.code',
+        multipleCardinality: true,
+        choiceType: false
       }
     }
   },
   ServiceRequest: {
     primaryCodePath: 'code',
     paths: {
+      instantiatesUri: {
+        codeType: 'FHIR.code',
+        multipleCardinality: true,
+        choiceType: false
+      },
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      intent: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       category: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: true,
+        choiceType: false
+      },
+      priority: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
         choiceType: false
       },
       code: {
@@ -1308,6 +1858,11 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   Specimen: {
     primaryCodePath: 'type',
     paths: {
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       type: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: false,
@@ -1323,6 +1878,11 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   Substance: {
     primaryCodePath: 'code',
     paths: {
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       category: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: true,
@@ -1338,6 +1898,11 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   SupplyDelivery: {
     primaryCodePath: 'type',
     paths: {
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       type: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: false,
@@ -1348,8 +1913,18 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   SupplyRequest: {
     primaryCodePath: 'category',
     paths: {
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       category: {
         codeType: 'FHIR.CodeableConcept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      priority: {
+        codeType: 'FHIR.code',
         multipleCardinality: false,
         choiceType: false
       },
@@ -1368,6 +1943,16 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   Task: {
     primaryCodePath: 'code',
     paths: {
+      instantiatesUri: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      status: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
       statusReason: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: false,
@@ -1375,6 +1960,16 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
       },
       businessStatus: {
         codeType: 'FHIR.CodeableConcept',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      intent: {
+        codeType: 'FHIR.code',
+        multipleCardinality: false,
+        choiceType: false
+      },
+      priority: {
+        codeType: 'FHIR.code',
         multipleCardinality: false,
         choiceType: false
       },

--- a/util/codePaths.ts
+++ b/util/codePaths.ts
@@ -19,11 +19,6 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   ActivityDefinition: {
     primaryCodePath: 'topic',
     paths: {
-      url: {
-        codeType: 'FHIR.code',
-        multipleCardinality: false,
-        choiceType: false
-      },
       status: {
         codeType: 'FHIR.code',
         multipleCardinality: false,
@@ -219,11 +214,6 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   CarePlan: {
     primaryCodePath: 'category',
     paths: {
-      instantiatesUri: {
-        codeType: 'FHIR.code',
-        multipleCardinality: true,
-        choiceType: false
-      },
       status: {
         codeType: 'FHIR.code',
         multipleCardinality: false,
@@ -264,11 +254,6 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   ChargeItem: {
     primaryCodePath: 'code',
     paths: {
-      definitionUri: {
-        codeType: 'FHIR.code',
-        multipleCardinality: true,
-        choiceType: false
-      },
       status: {
         codeType: 'FHIR.code',
         multipleCardinality: false,
@@ -299,16 +284,6 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   ChargeItemDefinition: {
     primaryCodePath: 'code',
     paths: {
-      url: {
-        codeType: 'FHIR.code',
-        multipleCardinality: false,
-        choiceType: false
-      },
-      derivedFromUri: {
-        codeType: 'FHIR.code',
-        multipleCardinality: true,
-        choiceType: false
-      },
       status: {
         codeType: 'FHIR.code',
         multipleCardinality: false,
@@ -379,11 +354,6 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
         multipleCardinality: false,
         choiceType: false
       },
-      protocol: {
-        codeType: 'FHIR.code',
-        multipleCardinality: true,
-        choiceType: false
-      },
       prognosisCodeableConcept: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: true,
@@ -394,11 +364,6 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   Communication: {
     primaryCodePath: 'category',
     paths: {
-      instantiatesUri: {
-        codeType: 'FHIR.code',
-        multipleCardinality: true,
-        choiceType: false
-      },
       status: {
         codeType: 'FHIR.code',
         multipleCardinality: false,
@@ -593,11 +558,6 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
         codeType: 'FHIR.code',
         multipleCardinality: false,
         choiceType: false
-      },
-      reference: {
-        codeType: 'FHIR.code',
-        multipleCardinality: false,
-        choiceType: false
       }
     }
   },
@@ -616,11 +576,6 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
       },
       type: {
         codeType: 'FHIR.CodeableConcept',
-        multipleCardinality: false,
-        choiceType: false
-      },
-      url: {
-        codeType: 'FHIR.code',
         multipleCardinality: false,
         choiceType: false
       },
@@ -664,11 +619,6 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   DeviceRequest: {
     primaryCodePath: 'code',
     paths: {
-      instantiatesUri: {
-        codeType: 'FHIR.code',
-        multipleCardinality: true,
-        choiceType: false
-      },
       status: {
         codeType: 'FHIR.code',
         multipleCardinality: false,
@@ -1044,11 +994,6 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   Library: {
     primaryCodePath: 'topic',
     paths: {
-      url: {
-        codeType: 'FHIR.code',
-        multipleCardinality: false,
-        choiceType: false
-      },
       status: {
         codeType: 'FHIR.code',
         multipleCardinality: false,
@@ -1139,11 +1084,6 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   Measure: {
     primaryCodePath: 'topic',
     paths: {
-      url: {
-        codeType: 'FHIR.code',
-        multipleCardinality: false,
-        choiceType: false
-      },
       status: {
         codeType: 'FHIR.code',
         multipleCardinality: false,
@@ -1229,11 +1169,6 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   MedicationAdministration: {
     primaryCodePath: 'medication',
     paths: {
-      instantiates: {
-        codeType: 'FHIR.code',
-        multipleCardinality: true,
-        choiceType: false
-      },
       status: {
         codeType: 'FHIR.code',
         multipleCardinality: false,
@@ -1364,11 +1299,6 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
         multipleCardinality: true,
         choiceType: false
       },
-      instantiatesUri: {
-        codeType: 'FHIR.code',
-        multipleCardinality: true,
-        choiceType: false
-      },
       courseOfTherapyType: {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: false,
@@ -1409,11 +1339,6 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   MessageDefinition: {
     primaryCodePath: 'event',
     paths: {
-      url: {
-        codeType: 'FHIR.code',
-        multipleCardinality: false,
-        choiceType: false
-      },
       status: {
         codeType: 'FHIR.code',
         multipleCardinality: false,
@@ -1514,11 +1439,6 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   OperationDefinition: {
     primaryCodePath: 'code',
     paths: {
-      url: {
-        codeType: 'FHIR.code',
-        multipleCardinality: false,
-        choiceType: false
-      },
       status: {
         codeType: 'FHIR.code',
         multipleCardinality: false,
@@ -1568,11 +1488,6 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   Procedure: {
     primaryCodePath: 'code',
     paths: {
-      instantiatesUri: {
-        codeType: 'FHIR.code',
-        multipleCardinality: true,
-        choiceType: false
-      },
       status: {
         codeType: 'FHIR.code',
         multipleCardinality: false,
@@ -1628,11 +1543,6 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   Questionnaire: {
     primaryCodePath: 'name',
     paths: {
-      url: {
-        codeType: 'FHIR.code',
-        multipleCardinality: false,
-        choiceType: false
-      },
       status: {
         codeType: 'FHIR.code',
         multipleCardinality: false,
@@ -1673,11 +1583,6 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   RequestGroup: {
     primaryCodePath: 'code',
     paths: {
-      instantiatesUri: {
-        codeType: 'FHIR.code',
-        multipleCardinality: true,
-        choiceType: false
-      },
       status: {
         codeType: 'FHIR.code',
         multipleCardinality: false,
@@ -1733,11 +1638,6 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   SearchParameter: {
     primaryCodePath: 'target',
     paths: {
-      url: {
-        codeType: 'FHIR.code',
-        multipleCardinality: false,
-        choiceType: false
-      },
       status: {
         codeType: 'FHIR.code',
         multipleCardinality: false,
@@ -1788,11 +1688,6 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   ServiceRequest: {
     primaryCodePath: 'code',
     paths: {
-      instantiatesUri: {
-        codeType: 'FHIR.code',
-        multipleCardinality: true,
-        choiceType: false
-      },
       status: {
         codeType: 'FHIR.code',
         multipleCardinality: false,
@@ -1822,11 +1717,6 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
         codeType: 'FHIR.CodeableConcept',
         multipleCardinality: true,
         choiceType: false
-      },
-      quantity: {
-        codeType: 'FHIR.CodeableConcept',
-        multipleCardinality: false,
-        choiceType: true
       },
       asNeeded: {
         codeType: 'FHIR.CodeableConcept',
@@ -1943,11 +1833,6 @@ export const parsedCodePaths: Record<string, ResourceCodeInfo> = {
   Task: {
     primaryCodePath: 'code',
     paths: {
-      instantiatesUri: {
-        codeType: 'FHIR.code',
-        multipleCardinality: false,
-        choiceType: false
-      },
       status: {
         codeType: 'FHIR.code',
         multipleCardinality: false,

--- a/util/fhir.ts
+++ b/util/fhir.ts
@@ -7,6 +7,7 @@ import _ from 'lodash';
 import { ReferencesMap } from './referencesMap';
 import fhirpath from 'fhirpath';
 import { dateFieldInfo } from '../scripts/parsePrimaryDatePath';
+import { access } from 'fs';
 
 const DEFAULT_PERIOD_LENGTH = 1;
 
@@ -85,16 +86,18 @@ export function getPatientNameString(patient: fhir4.Patient) {
  * @returns {String} displaying the valuesets referenced by a DataRequirement
  */
 export function getDataRequirementFiltersString(dr: fhir4.DataRequirement, valueSetMap: ValueSetsMap): string {
+  let system, version, code, display;
   const valueSets = dr.codeFilter?.reduce((acc: string[], e) => {
     if (e.valueSet) {
       acc.push(`${valueSetMap[e.valueSet]} (${e.valueSet})`);
     }
-    if (e.path === 'code' && e.code) {
-      acc.push(...e.code.map(c => c.display ?? 'Un-named Code'));
+    if (e.code) {
+      acc.push(...e.code.map(c => (c.display ? `${c.code}: ${c.display}` : '')));
     }
     return acc;
   }, []);
-  if (valueSets) {
+  if (valueSets && valueSets.length > 0) {
+    console.log(`${valueSets?.join('\n')}`);
     return `${valueSets?.join('\n')}`;
   }
   return '';

--- a/util/fhir.ts
+++ b/util/fhir.ts
@@ -173,6 +173,8 @@ function getResourcePatientReference(resource: any, dr: fhir4.DataRequirement, p
 
 function getResourcePrimaryCode(resource: any, dr: fhir4.DataRequirement, mb: fhir4.Bundle) {
   // resource properties retrieved from data requirements
+  // 1. iterate over code filters and try to do everything the code filter is saying before continuing
+  // after that we don't need to revisit the code filters
   dr.codeFilter?.forEach(cf => {
     if (!cf.valueSet && cf.path && cf.code) {
       resource[cf.path] = cf.code[0].code;

--- a/util/fhir.ts
+++ b/util/fhir.ts
@@ -173,8 +173,6 @@ function getResourcePatientReference(resource: any, dr: fhir4.DataRequirement, p
 
 function getResourcePrimaryCode(resource: any, dr: fhir4.DataRequirement, mb: fhir4.Bundle) {
   // resource properties retrieved from data requirements
-  // 1. iterate over code filters and try to do everything the code filter is saying before continuing
-  // after that we don't need to revisit the code filters
   dr.codeFilter?.forEach(cf => {
     if (!cf.valueSet && cf.path && cf.code) {
       resource[cf.path] = cf.code[0].code;

--- a/util/types.ts
+++ b/util/types.ts
@@ -8,3 +8,12 @@ export interface CodePathInfo {
   multipleCardinality: boolean;
   choiceType: boolean;
 }
+
+export interface ResourceCodeInfo {
+  primaryCodePath: string;
+  paths: CodePathInfo;
+}
+
+export interface CodePathInfo {
+  [key: string]: { codeType: string; multipleCardinality: boolean };
+}

--- a/util/types.ts
+++ b/util/types.ts
@@ -8,12 +8,3 @@ export interface CodePathInfo {
   multipleCardinality: boolean;
   choiceType: boolean;
 }
-
-export interface ResourceCodeInfo {
-  primaryCodePath: string;
-  paths: CodePathInfo;
-}
-
-export interface CodePathInfo {
-  [key: string]: { codeType: string; multipleCardinality: boolean };
-}


### PR DESCRIPTION
# Summary
When testing fqm-testify with the "DRCommunicationWithPhysicianManagingDiabetesFHIR-bundle" bundle, Dave noticed that the app crashed and was not able to display data elements with direct reference codes.

## New Behavior
All of the components of the app are the same, but now when a data element doesn't have a valueSet but has a direct reference code, that is what is displayed in the test resource display panel and the scaffolded FHIR resource JSON. In addition, the code and display shown under each test resource for a patient display the direct reference code and display if it exists.

In general, the application now adds all code paths of type FHIR.CodeableConcept, FHIR.Coding, and FHIR.code to the scaffolded FHIR resource JSON. Changes in associated files were made to reflect the changes in parseCodePaths.js.

## Code Changes
- `types.ts` - the structure of the codePaths.ts file was modified so that each dataRequirement object can have more than one path object.
- `parseCodePaths.ts` / `parsePrimaryCodePaths.ts` - modified script that now parses all code type paths for data requirements rather than just the primary code path which is why `parsePrimaryCodePaths.ts` was renamed to `parseCodePaths.ts`. These changes are shown in the previous PR for this with the addition of being able to find elements of type System.string that are embedded in FHIR.Elements. These are just FHIR.code type paths so they are now included in the parse code paths output file.
- `codePaths.ts` / `primaryCodePaths.ts` - `codePaths.ts` replaced `primaryCodePaths.ts` because the new script parses all code paths of all code types into that file. not just the primaryCodePath. The file was renamed to reflect this change.
- `fhir.ts` - functions such as `createFhirResourceString`, `getFhirResourceSummary`, and `getResourcePrimaryCode` were modified to reflect the changes in `codePaths.ts` as well display direct reference codes and add them to the scaffolded Fhir resource JSON.
- `fhir.test.ts` - unit tests updated to reflect changes to `fhir.ts`.
- `package.json` - fixed small mix up.

# Testing Guidance
1. Please ask me questions if any of this doesn't make sense.
2. Run `npm run test` and make sure that all of the tests pass. 
3. Run `npm run dev`
4. Upload the measure bundle "DRCommunicationWithPhysicianManagingDiabetesFHIR-bundle" that is linked on the Jira ticket for this task (#1108). It is also in the slack thread that is linked below. 
5. Create a new patient. Scroll through the available data elements. There are two "Communication" elements that have direct reference codes rather than valuesets. They should look like the following:

<img width="570" alt="image" src="https://user-images.githubusercontent.com/30158156/187484117-b8e250ea-69b8-4b8e-928f-a9ba3a1bba08.png">

6. Try uploading other measure bundles, with or without direct reference codes, and make sure nothing breaks and everything looks correct. 