### PR TITLE
Duplicate patient

### DIFF
--- a/__tests__/components/patient-creation/PatientCreationPanel.test.tsx
+++ b/__tests__/components/patient-creation/PatientCreationPanel.test.tsx
@@ -125,6 +125,38 @@ describe('PatientCreationPanel', () => {
     expect(confirmationModal).toBeInTheDocument();
   });
 
+  it('should render modal when copy button is clicked', () => {
+    const MockPatients = getMockRecoilState(patientTestCaseState, {
+      'example-pt': {
+        patient: {
+          resourceType: 'Patient',
+          name: [{ given: ['Test123'], family: 'Patient456' }]
+        },
+        resources: []
+      }
+    });
+
+    const MockSelectedPatient = getMockRecoilState(selectedPatientState, 'example-pt');
+
+    render(
+      mantineRecoilWrap(
+        <>
+          <MockPatients />
+          <MockSelectedPatient />
+          <PatientCreationPanel />
+        </>
+      )
+    );
+
+    const copyButton = screen.getByLabelText(/copy patient/i) as HTMLButtonElement;
+    expect(copyButton).toBeInTheDocument();
+
+    fireEvent.click(copyButton);
+
+    const modal = screen.getByRole('dialog');
+    expect(modal).toBeInTheDocument();
+  });
+
   it('should have download function called when download patient button is clicked', async () => {
     const MockPatients = getMockRecoilState(patientTestCaseState, {
       'example-pt': {

--- a/__tests__/components/utils/PatientInfoCard.test.tsx
+++ b/__tests__/components/utils/PatientInfoCard.test.tsx
@@ -13,7 +13,8 @@ const EXAMPLE_PATIENT: fhir4.Patient = {
 const MOCK_CALLBACK_PROPS: Omit<PatientInfoCardProps, 'patient'> = {
   onEditClick: jest.fn(),
   onDeleteClick: jest.fn(),
-  onExportClick: jest.fn()
+  onExportClick: jest.fn(),
+  onCopyClick: jest.fn()
 };
 
 describe('PatientInfoCard', () => {
@@ -45,6 +46,12 @@ describe('PatientInfoCard', () => {
     expect(screen.getByLabelText(/edit patient/i)).toBeInTheDocument();
   });
 
+  it('should render copy button', () => {
+    render(mantineRecoilWrap(<PatientInfoCard patient={EXAMPLE_PATIENT} {...MOCK_CALLBACK_PROPS} />));
+
+    expect(screen.getByLabelText(/copy patient/i)).toBeInTheDocument();
+  });
+
   it('should render delete button', () => {
     render(mantineRecoilWrap(<PatientInfoCard patient={EXAMPLE_PATIENT} {...MOCK_CALLBACK_PROPS} />));
 
@@ -61,6 +68,7 @@ describe('PatientInfoCard', () => {
     expect(MOCK_CALLBACK_PROPS.onExportClick).toHaveBeenCalledTimes(1);
     expect(MOCK_CALLBACK_PROPS.onEditClick).toHaveBeenCalledTimes(0);
     expect(MOCK_CALLBACK_PROPS.onDeleteClick).toHaveBeenCalledTimes(0);
+    expect(MOCK_CALLBACK_PROPS.onCopyClick).toHaveBeenCalledTimes(0);
   });
 
   it('should call edit callback when button clicked', () => {
@@ -71,6 +79,20 @@ describe('PatientInfoCard', () => {
     fireEvent.click(editButton);
 
     expect(MOCK_CALLBACK_PROPS.onEditClick).toHaveBeenCalledTimes(1);
+    expect(MOCK_CALLBACK_PROPS.onExportClick).toHaveBeenCalledTimes(0);
+    expect(MOCK_CALLBACK_PROPS.onDeleteClick).toHaveBeenCalledTimes(0);
+    expect(MOCK_CALLBACK_PROPS.onCopyClick).toHaveBeenCalledTimes(0);
+  });
+
+  it('should call copy callback when button clicked', () => {
+    render(mantineRecoilWrap(<PatientInfoCard patient={EXAMPLE_PATIENT} {...MOCK_CALLBACK_PROPS} />));
+
+    const editButton = screen.getByLabelText(/copy patient/i) as HTMLButtonElement;
+
+    fireEvent.click(editButton);
+
+    expect(MOCK_CALLBACK_PROPS.onCopyClick).toHaveBeenCalledTimes(1);
+    expect(MOCK_CALLBACK_PROPS.onEditClick).toHaveBeenCalledTimes(0);
     expect(MOCK_CALLBACK_PROPS.onExportClick).toHaveBeenCalledTimes(0);
     expect(MOCK_CALLBACK_PROPS.onDeleteClick).toHaveBeenCalledTimes(0);
   });
@@ -85,5 +107,6 @@ describe('PatientInfoCard', () => {
     expect(MOCK_CALLBACK_PROPS.onDeleteClick).toHaveBeenCalledTimes(1);
     expect(MOCK_CALLBACK_PROPS.onExportClick).toHaveBeenCalledTimes(0);
     expect(MOCK_CALLBACK_PROPS.onEditClick).toHaveBeenCalledTimes(0);
+    expect(MOCK_CALLBACK_PROPS.onCopyClick).toHaveBeenCalledTimes(0);
   });
 });

--- a/__tests__/utils/fhir.test.ts
+++ b/__tests__/utils/fhir.test.ts
@@ -338,6 +338,60 @@ const EXAMPLE_FIELD_CHOICE_TYPE_DATE: dateFieldInfo = {
 
 const EXAMPLE_PATH = 'testPath';
 
+const PATIENT_RESOURCE: fhir4.Patient = {
+  resourceType: 'Patient',
+  id: 'Patient1'
+};
+
+const PATIENT_RESOURCE_W_DETAILS: fhir4.Patient = {
+  resourceType: 'Patient',
+  id: 'Patient2',
+  identifier: [
+    {
+      system: 'http://example.com/test-id',
+      value: `test-patient-Patient2`
+    }
+  ],
+  gender: 'male',
+  name: [
+    {
+      family: 'Smith',
+      given: ['John']
+    }
+  ]
+};
+
+const ENCOUNTER_RESOURCE: fhir4.Encounter = {
+  resourceType: 'Encounter',
+  id: 'Encounter1',
+  status: 'finished',
+  class: { code: 'AMB' },
+  type: [
+    {
+      coding: [
+        {
+          system: 'https://www.cms.gov/Medicare/Coding/MedHCPCSGenInfo/index.html',
+          version: '2018',
+          code: 'G0438',
+          display: 'Annual wellness visit; includes a personalized prevention plan of service (pps), initial visit'
+        }
+      ]
+    }
+  ]
+};
+
+const OBSERVATION_RESOURCE: fhir4.Observation = {
+  resourceType: 'Observation',
+  id: 'Observation1',
+  code: {
+    coding: [
+      {
+        code: 'Test Obs'
+      }
+    ]
+  },
+  status: 'final'
+};
 describe('getDataRequirementFiltersString', () => {
   test('returns an empty string for resource with no valuesets and no direct reference code', () => {
     expect(getDataRequirementFiltersString(DATA_REQUIREMENT_WITH_NO_VALUESETS_OR_DRC, VS_MAP)).toEqual('');
@@ -524,61 +578,6 @@ describe('createFHIRResourceString', () => {
     });
   });
 });
-
-const PATIENT_RESOURCE: fhir4.Patient = {
-  resourceType: 'Patient',
-  id: 'Patient1'
-};
-
-const PATIENT_RESOURCE_W_DETAILS: fhir4.Patient = {
-  resourceType: 'Patient',
-  id: 'Patient2',
-  identifier: [
-    {
-      system: 'http://example.com/test-id',
-      value: `test-patient-Patient2`
-    }
-  ],
-  gender: 'male',
-  name: [
-    {
-      family: 'Smith',
-      given: ['John']
-    }
-  ]
-};
-
-const ENCOUNTER_RESOURCE: fhir4.Encounter = {
-  resourceType: 'Encounter',
-  id: 'Encounter1',
-  status: 'finished',
-  class: { code: 'AMB' },
-  type: [
-    {
-      coding: [
-        {
-          system: 'https://www.cms.gov/Medicare/Coding/MedHCPCSGenInfo/index.html',
-          version: '2018',
-          code: 'G0438',
-          display: 'Annual wellness visit; includes a personalized prevention plan of service (pps), initial visit'
-        }
-      ]
-    }
-  ]
-};
-
-const OBSERVATION_RESOURCE: fhir4.Observation = {
-  resourceType: 'Observation',
-  id: 'Observation1',
-  code: {
-    coding: [
-      {
-        code: 'Test Obs'
-      }
-    ]
-  },
-  status: 'final'
-};
 
 describe('createPatientBundle', () => {
   test('can create bundle just patient', () => {

--- a/components/patient-creation/PatientCreationPanel.tsx
+++ b/components/patient-creation/PatientCreationPanel.tsx
@@ -5,7 +5,13 @@ import produce from 'immer';
 import CodeEditorModal from '../modals/CodeEditorModal';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { patientTestCaseState, TestCaseInfo } from '../../state/atoms/patientTestCase';
-import { createPatientResourceString, getPatientNameString, createPatientBundle } from '../../util/fhir';
+import {
+  createPatientResourceString,
+  getPatientNameString,
+  createPatientBundle,
+  createCopiedPatientResource,
+  createCopiedResources
+} from '../../util/fhir';
 import { measurementPeriodState } from '../../state/atoms/measurementPeriod';
 import { selectedPatientState } from '../../state/atoms/selectedPatient';
 import React, { ReactNode, useState } from 'react';
@@ -18,10 +24,12 @@ import ImportModal from '../modals/ImportModal';
 import { bundleToTestCase } from '../../util/import';
 import PatientInfoCard from '../utils/PatientInfoCard';
 import PopulationCalculation from '../calculation/PopulationCalculation';
+import { FhirResource } from '@fhir-typescript/r4-core/dist/fhirJson';
 
 function PatientCreationPanel() {
   const [isPatientModalOpen, setIsPatientModalOpen] = useState(false);
   const [currentPatient, setCurrentPatient] = useState<string | null>(null);
+  const [copiedPatient, setCopiedPatient] = useState<string | null>(null);
   const [isConfirmationModalOpen, setIsConfirmationModalOpen] = useState(false);
   const [isImportModalOpen, setIsImportModalOpen] = useState(false);
 
@@ -30,9 +38,14 @@ function PatientCreationPanel() {
   const measureBundle = useRecoilValue(measureBundleState);
   const measurementPeriod = useRecoilValue(measurementPeriodState);
 
-  const openPatientModal = (patientId?: string) => {
+  const openPatientModal = (patientId?: string, copy = false) => {
     if (patientId && Object.keys(currentPatients).includes(patientId)) {
-      setCurrentPatient(patientId);
+      if (copy) {
+        setCurrentPatient(null);
+        setCopiedPatient(patientId);
+      } else {
+        setCurrentPatient(patientId);
+      }
     } else {
       setCurrentPatient(null);
     }
@@ -43,20 +56,27 @@ function PatientCreationPanel() {
   const closePatientModal = () => {
     setIsPatientModalOpen(false);
     setCurrentPatient(null);
+    setCopiedPatient(null);
   };
 
   const updatePatientTestCase = (val: string) => {
     // TODO: Validate the incoming JSON as FHIR
     const pt = JSON.parse(val.trim()) as fhir4.Patient;
-
     if (pt.id) {
       const patientId = pt.id;
 
+      let resources: fhir4.FhirResource[];
+      // save new resources for a copied patient
+      if (copiedPatient) {
+        const pat = currentPatients[copiedPatient];
+        resources = createCopiedResources(pat.resources, pat.patient.id ?? '', patientId);
+      } else {
+        resources = currentPatients[patientId]?.resources ?? [];
+      }
       // Create a new state object using immer without needing to shallow clone the entire previous object
       const nextPatientState = produce(currentPatients, draftState => {
-        draftState[patientId] = { patient: pt, resources: currentPatients[patientId]?.resources ?? [] };
+        draftState[patientId] = { patient: pt, resources: resources };
       });
-
       setCurrentPatients(nextPatientState);
     }
 
@@ -98,6 +118,10 @@ function PatientCreationPanel() {
     if (isPatientModalOpen) {
       if (currentPatient) {
         return JSON.stringify(currentPatients[currentPatient].patient, null, 2);
+      } else if (copiedPatient) {
+        // Create copy of copiedPatient
+        const patient = createCopiedPatientResource(currentPatients[copiedPatient].patient);
+        return JSON.stringify(patient, null, 2);
       } else {
         // Default to age 21 at time of measurement period, if specified
         const birthDate = measurementPeriod.start ? new Date(measurementPeriod.start) : new Date();
@@ -310,6 +334,7 @@ function PatientCreationPanel() {
               >
                 <PatientInfoCard
                   patient={testCase.patient}
+                  onCopyClick={() => openPatientModal(id, true)}
                   onExportClick={() => exportPatientTestCase(id)}
                   onEditClick={() => openPatientModal(id)}
                   onDeleteClick={() => openConfirmationModal()}

--- a/components/patient-creation/PatientCreationPanel.tsx
+++ b/components/patient-creation/PatientCreationPanel.tsx
@@ -24,7 +24,6 @@ import ImportModal from '../modals/ImportModal';
 import { bundleToTestCase } from '../../util/import';
 import PatientInfoCard from '../utils/PatientInfoCard';
 import PopulationCalculation from '../calculation/PopulationCalculation';
-import { FhirResource } from '@fhir-typescript/r4-core/dist/fhirJson';
 
 function PatientCreationPanel() {
   const [isPatientModalOpen, setIsPatientModalOpen] = useState(false);

--- a/components/utils/PatientInfoCard.tsx
+++ b/components/utils/PatientInfoCard.tsx
@@ -1,10 +1,11 @@
 import { Button, Center, Divider, Grid, Paper, Sx, Text, Tooltip } from '@mantine/core';
 import React from 'react';
-import { Download, Edit, Trash } from 'tabler-icons-react';
+import { Copy, Download, Edit, Trash } from 'tabler-icons-react';
 import { getPatientDOBString, getPatientNameString } from '../../util/fhir';
 
 export interface PatientInfoCardProps {
   patient: fhir4.Patient;
+  onCopyClick: (...args: unknown[]) => void;
   onExportClick: (...args: unknown[]) => void;
   onEditClick: (...args: unknown[]) => void;
   onDeleteClick: (...args: unknown[]) => void;
@@ -13,6 +14,7 @@ export interface PatientInfoCardProps {
 
 export default function PatientInfoCard({
   patient,
+  onCopyClick,
   onExportClick,
   onEditClick,
   onDeleteClick,
@@ -73,6 +75,19 @@ export default function PatientInfoCard({
                 size="xs"
               >
                 <Edit />
+              </Button>
+            </Tooltip>
+            <Tooltip label="Copy Patient" openDelay={1000}>
+              <Button
+                size="xs"
+                data-testid="copy-patient-button"
+                aria-label={'Copy Patient'}
+                onClick={() => {
+                  onCopyClick();
+                }}
+                variant="subtle"
+              >
+                <Copy />
               </Button>
             </Tooltip>
             <Divider sx={{ height: '48px' }} size="xs" orientation="vertical" />

--- a/components/utils/PatientInfoCard.tsx
+++ b/components/utils/PatientInfoCard.tsx
@@ -80,7 +80,6 @@ export default function PatientInfoCard({
             <Tooltip label="Copy Patient" openDelay={1000}>
               <Button
                 size="xs"
-                data-testid="copy-patient-button"
                 aria-label={'Copy Patient'}
                 onClick={() => {
                   onCopyClick();

--- a/components/utils/PatientInfoCard.tsx
+++ b/components/utils/PatientInfoCard.tsx
@@ -51,7 +51,7 @@ export default function PatientInfoCard({
             </Text>
           </div>
         </Grid.Col>
-        <Grid.Col span={5} offset={2} style={{ paddingRight: 0 }}>
+        <Grid.Col span={5} offset={2} style={{ paddingRight: 25 }}>
           <Center>
             <Tooltip label="Export Patient" openDelay={1000}>
               <Button

--- a/util/fhir.ts
+++ b/util/fhir.ts
@@ -39,6 +39,14 @@ export function createPatientResourceString(birthDate: string): string {
   return JSON.stringify(pt, null, 2);
 }
 
+/**
+ * Creates copies of all passed in resources (without references maintained) and gives them
+ * new resource ids. Replaces all patient references to the patient oldId with newId
+ * @param copyResources {fhir4.FhirResource[]} array of fhir resources to be copied
+ * @param oldId {String} a patient id that the copyResources may reference
+ * @param newId {String} a patient id that should replace oldId in references
+ * @returns {fhir4.FhirResource[]} array of new resource copies
+ */
 export function createCopiedResources(
   copyResources: fhir4.FhirResource[],
   oldId: string,
@@ -56,6 +64,12 @@ export function createCopiedResources(
   return resources;
 }
 
+/**
+ * Creates a copy of the passed in patient object (without references maintained) and updates the
+ * id and identifier as well as creating a new name to differentiate the new patient copy
+ * @param copyPatient {fhir4.Patient} a fhir Patient object to copy
+ * @returns {fhir4.Patient} the new fhir patient copy
+ */
 export function createCopiedPatientResource(copyPatient: fhir4.Patient): fhir4.Patient {
   const patient: fhir4.Patient = _.cloneDeep(copyPatient);
   const identifier = patient.identifier?.find(id => id.system === 'http://example.com/test-id');
@@ -63,20 +77,15 @@ export function createCopiedPatientResource(copyPatient: fhir4.Patient): fhir4.P
   if (identifier) {
     identifier.value = `test-patient-${patient.id}`;
   } else {
+    const newIdentifier: fhir4.Identifier = {
+      use: 'usual',
+      system: 'http://example.com/test-id',
+      value: `test-patient-${patient.id}`
+    };
     if (patient.identifier) {
-      patient.identifier.push({
-        use: 'usual',
-        system: 'http://example.com/test-id',
-        value: `test-patient-${patient.id}`
-      });
+      patient.identifier.push(newIdentifier);
     } else {
-      patient.identifier = [
-        {
-          use: 'usual',
-          system: 'http://example.com/test-id',
-          value: `test-patient-${patient.id}`
-        }
-      ];
+      patient.identifier = [newIdentifier];
     }
   }
   if (patient.name && patient.name.length > 0) {


### PR DESCRIPTION
# Summary
Adds a button and logic for copying a patient test case.

## New Behavior
Addresses user story:
(Story 12) As a user, I want to be able to clone an existing patient test case so that I can only modify a few things. I should be able to clone an existing patient, and a new patient should show up that is a duplicate of the previous one.
The new patient should have a different ID than the one I cloned, but the rest of the patient resource should be the same. The new patient's associated data elements should also have different IDs, and their FHIR references should be updated to reflect

## Code Changes
- `PatientCreationPanel,` creates a copiedPatient state to track the patient to be copied. Loads model and creates initial draft copy patient json data to display to the user. Creates copied resources when the new copy patient data is saved by the user.
- `PatientInfoCard`, new copy tooltip button that launches onCopyClick()
- `fhir.ts`, new functions for copying the patient data and for copying the associated resources and reassigning their patient references
- Tests for the above files


# Testing Guidance
Run unit tests with `npm run test`
Run `npm run dev` and try copy patient at `localhost:3000` by:
- Adding a bundle with drag and drop
- Creating and saving a patient
- Selecting the patient and select a resource to save to the patient
- Click the copy button
- Confirm that the copied resource contains the same information but with different names and ids (with all resource references to the appropriate patient id). You can either download both patients and compare ids or compare in the app's json editor.

Experiment with variations on the above.