### PR TITLE
Add ability to create resource not from data requirements

### DIFF
--- a/__tests__/components/resource-creation/ResourcePanel.test.tsx
+++ b/__tests__/components/resource-creation/ResourcePanel.test.tsx
@@ -91,7 +91,7 @@ describe('ResourcePanel', () => {
     expect(addNewResourceButton).toBeInTheDocument();
   });
 
-  it('should render modal when Add New Resource button is clicked', async () => {
+  it('should render modal when Add New Custom Resource button is clicked', async () => {
     const MockSelectedPatient = getMockRecoilState(selectedPatientState, 'example-pt');
     const MockPatientState = getMockRecoilState(patientTestCaseState, {
       'example-pt': {

--- a/__tests__/components/resource-creation/ResourcePanel.test.tsx
+++ b/__tests__/components/resource-creation/ResourcePanel.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { act, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { mantineRecoilWrap, getMockRecoilState } from '../../helpers/testHelpers';
 import { patientTestCaseState } from '../../../state/atoms/patientTestCase';
 import React from 'react';
@@ -53,5 +53,82 @@ describe('ResourcePanel', () => {
     });
 
     expect(screen.getByText(/test123 patient456 resources \(0\)/i)).toBeInTheDocument();
+  });
+
+  it('should render button for adding custom resource when patient is selected', async () => {
+    const MockSelectedPatient = getMockRecoilState(selectedPatientState, 'example-pt');
+    const MockPatientState = getMockRecoilState(patientTestCaseState, {
+      'example-pt': {
+        patient: {
+          resourceType: 'Patient',
+          id: 'example-pt',
+          name: [
+            {
+              given: ['Test123'],
+              family: 'Patient456'
+            }
+          ]
+        } as fhir4.Patient,
+        resources: []
+      }
+    });
+
+    await act(async () => {
+      render(
+        mantineRecoilWrap(
+          <>
+            <MockPatientState />
+            <MockSelectedPatient />
+            <ResourcePanel />
+          </>
+        )
+      );
+    });
+
+    const addNewResourceButton = screen.getByRole('button', {
+      name: /add new custom resource/i
+    });
+    expect(addNewResourceButton).toBeInTheDocument();
+  });
+
+  it('should render modal when Add New Resource button is clicked', async () => {
+    const MockSelectedPatient = getMockRecoilState(selectedPatientState, 'example-pt');
+    const MockPatientState = getMockRecoilState(patientTestCaseState, {
+      'example-pt': {
+        patient: {
+          resourceType: 'Patient',
+          id: 'example-pt',
+          name: [
+            {
+              given: ['Test123'],
+              family: 'Patient456'
+            }
+          ]
+        } as fhir4.Patient,
+        resources: []
+      }
+    });
+
+    render(
+      mantineRecoilWrap(
+        <>
+          <MockPatientState />
+          <MockSelectedPatient />
+          <ResourcePanel />
+        </>
+      )
+    );
+
+    const addNewResourceButton = screen.getByRole('button', {
+      name: /add new custom resource/i
+    });
+    expect(addNewResourceButton).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(addNewResourceButton);
+    });
+
+    const modal = screen.getByRole('dialog');
+    expect(modal).toBeInTheDocument();
   });
 });

--- a/components/resource-creation/ResourcePanel.tsx
+++ b/components/resource-creation/ResourcePanel.tsx
@@ -1,6 +1,6 @@
 import { Button, Center, Divider, Text } from '@mantine/core';
 import { v4 as uuidv4 } from 'uuid';
-import { IconCodePlus } from '@tabler/icons';
+import { IconAlertCircle, IconCodePlus } from '@tabler/icons';
 import { Suspense, useState } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { Loader } from 'tabler-icons-react';
@@ -11,6 +11,7 @@ import produce from 'immer';
 import CodeEditorModal from '../modals/CodeEditorModal';
 import ResourceDisplay from './ResourceDisplay';
 import ResourceSelection from './ResourceSelection';
+import { showNotification } from '@mantine/notifications';
 
 export default function ResourcePanel() {
   const selectedPatient = useRecoilValue(selectedPatientState);
@@ -25,10 +26,21 @@ export default function ResourcePanel() {
       if (!newResource.id) {
         newResource.id = uuidv4();
       }
-      const nextResourceState = produce(currentPatients, draftState => {
-        draftState[selectedPatient].resources.push(newResource);
-      });
-      setCurrentPatients(nextResourceState);
+      const resourceIndex = currentPatients[selectedPatient].resources.findIndex(r => r.id === newResource.id);
+      if (resourceIndex >= 0) {
+        showNotification({
+          id: 'failed-upload',
+          icon: <IconAlertCircle />,
+          title: 'Resource Creation Failed',
+          message: `Resource ID ${newResource.id} is used for an existing resource for this patient.`,
+          color: 'red'
+        });
+      } else {
+        const nextResourceState = produce(currentPatients, draftState => {
+          draftState[selectedPatient].resources.push(newResource);
+        });
+        setCurrentPatients(nextResourceState);
+      }
     }
     setIsNewResourceModalOpen(false);
   };
@@ -70,7 +82,7 @@ export default function ResourcePanel() {
           }}
         >
           <ResourceSelection />
-          <Center>Or</Center>
+          <Center>or</Center>
           <Center>
             <Button
               aria-label="Add New Custom Resource"

--- a/components/resource-creation/ResourcePanel.tsx
+++ b/components/resource-creation/ResourcePanel.tsx
@@ -1,16 +1,37 @@
-import { Center, Divider, Text } from '@mantine/core';
-import { Suspense } from 'react';
-import { useRecoilValue } from 'recoil';
+import { Button, Center, Divider, Text } from '@mantine/core';
+import { v4 as uuidv4 } from 'uuid';
+import { IconCodePlus } from '@tabler/icons';
+import { Suspense, useState } from 'react';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import { Loader } from 'tabler-icons-react';
 import { patientTestCaseState } from '../../state/atoms/patientTestCase';
 import { selectedPatientState } from '../../state/atoms/selectedPatient';
 import { getPatientNameString } from '../../util/fhir';
+import produce from 'immer';
+import CodeEditorModal from '../modals/CodeEditorModal';
 import ResourceDisplay from './ResourceDisplay';
 import ResourceSelection from './ResourceSelection';
 
 export default function ResourcePanel() {
   const selectedPatient = useRecoilValue(selectedPatientState);
-  const currentPatients = useRecoilValue(patientTestCaseState);
+  const [currentPatients, setCurrentPatients] = useRecoilState(patientTestCaseState);
+  const [isNewResourceModalOpen, setIsNewResourceModalOpen] = useState(false);
+
+  const createNewResource = (val: string) => {
+    // TODO: Validate the incoming JSON as FHIR
+    const newResource = JSON.parse(val.trim());
+    // Create a new state object using immer without needing to shallow clone the entire previous object
+    if (selectedPatient) {
+      if (!newResource.id) {
+        newResource.id = uuidv4();
+      }
+      const nextResourceState = produce(currentPatients, draftState => {
+        draftState[selectedPatient].resources.push(newResource);
+      });
+      setCurrentPatients(nextResourceState);
+    }
+    setIsNewResourceModalOpen(false);
+  };
 
   const renderPanelPlaceholderText = () => {
     return (
@@ -20,7 +41,7 @@ export default function ResourcePanel() {
     );
   };
 
-  const renderResourceSelectBox = () => {
+  const renderResourceSelection = () => {
     if (Object.keys(currentPatients).length === 0 || selectedPatient == null) {
       return renderPanelPlaceholderText();
     }
@@ -33,6 +54,12 @@ export default function ResourcePanel() {
           </Center>
         }
       >
+        <CodeEditorModal
+          open={isNewResourceModalOpen}
+          onClose={() => setIsNewResourceModalOpen(false)}
+          title="Add JSON for new FHIR Resource"
+          onSave={createNewResource}
+        />
         <Text>
           {getPatientNameString(currentPatients[selectedPatient].patient)} Resources (
           {currentPatients[selectedPatient].resources.length})
@@ -43,6 +70,17 @@ export default function ResourcePanel() {
           }}
         >
           <ResourceSelection />
+          <Center>Or</Center>
+          <Center>
+            <Button
+              aria-label="Add New Custom Resource"
+              onClick={() => setIsNewResourceModalOpen(true)}
+              variant="outline"
+            >
+              <IconCodePlus />
+              &nbsp;Add New Custom Resource
+            </Button>
+          </Center>
           <Divider my="lg" />
         </div>
       </Suspense>
@@ -51,7 +89,7 @@ export default function ResourcePanel() {
 
   return (
     <>
-      {renderResourceSelectBox()}
+      {renderResourceSelection()}
       <ResourceDisplay />
     </>
   );

--- a/components/resource-creation/ResourcePanel.tsx
+++ b/components/resource-creation/ResourcePanel.tsx
@@ -40,9 +40,9 @@ export default function ResourcePanel() {
           draftState[selectedPatient].resources.push(newResource);
         });
         setCurrentPatients(nextResourceState);
+        setIsNewResourceModalOpen(false);
       }
     }
-    setIsNewResourceModalOpen(false);
   };
 
   const renderPanelPlaceholderText = () => {

--- a/components/resource-creation/ResourceSelection.tsx
+++ b/components/resource-creation/ResourceSelection.tsx
@@ -45,7 +45,7 @@ export default function ResourceSelection() {
         ref={drSelectRef}
         maxDropdownHeight={500}
         searchable
-        placeholder="Select FHIR Resource"
+        placeholder="Select FHIR Resource (from Data Requirements)"
         value=""
         data={
           dataRequirements?.map((dr, i) => {


### PR DESCRIPTION
# Summary
Adds the ability for the user to add any FHIR resource to a given test case so that the user is not restricted to only the resources derived from the data requirements.

## New Behavior
The user now has the option to select a resource (derived from the data requirements) from the select component, or to add a new resource to the test case by pasting the resource JSON in a blank modal that will create the new resource in the resource panel. 

## Code Changes
* `resource-creation/ResourcePanel`
    * New button “Add New Custom Resource” that will bring up the blank modal for inputting FHIR JSON data
    * New function `createNewResource` to create the new FHIR resource from the JSON and add it to the selected patient (Note: right now, the function ensures that the new resource has an id since that is needed for editing the resource from the ResourceInfoCard. In the future, we will need to validate the incoming JSON as FHIR. Is there anything else that should be checked as of now like resource type or any other important fields?)
* `resource-creation/ResourceSelection`
    * Changed the placeholder text on the select dropdown so that the two resource creation methods are more clear

# Testing Guidance
* After uploading a measure bundle and selecting a patient, try to add a new resource by clicking on the “Add New Custom Resource” button
* Input JSON into the modal and click Save
    * Try a FHIR resource from an EXM bundle, an empty JSON object, a JSON object without a resource type, etc. to try and see if anything breaks or if any errors should be thrown for missing information
    * Try all the resource info functionality with this new resource once it is created - deleting it, editing it, etc.
* Run the unit tests