### PR TITLE
MB upload information added to readme and app

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ After starting up the app, begin by uploading a FHIR Measure Bundle JSON file fr
 
 #### Adding ValueSets to FHIR Measure Bundle
 
-The user will see an error when uploading a FHIR Measure Bundle unless it has the following things: one measure resource, all dependent library resources used, and all ValueSets needed for measure calculation. If the Measure Bundle is missing ValueSets, then the user can add ValueSets by running [the fqm-execution library](https://github.com/projecttacoma/fqm-execution) CLI with the following command:
+The user will see an error when uploading a FHIR Measure Bundle unless it has the following things: exactly one measure resource, all dependent library resources used, and all ValueSets needed for measure calculation. If the Measure Bundle is missing ValueSets, then the user can add ValueSets by running [the fqm-execution library](https://github.com/projecttacoma/fqm-execution) CLI with the following command:
 
 ```bash
 ./src/cli.ts valueSets -m <path to measure bundle> --vs-api-key <api key>
@@ -98,6 +98,7 @@ FQM-Testify allows for exporting of all test cases by clicking the "Download All
 ### Running Measure Calculation on a Test Case
 
 FQM-Testify can run measure calculation on a single test case for a given measure. Selecting a patient entry triggers calculation and displays logic highlighting using [the fqm-execution library](https://github.com/projecttacoma/fqm-execution) in the right panel. Measure calculation automatically regenerates for a patient if:
+
 - non-patient test resources are added for the patient
 - existing test resources that belong to the patient are edited
 - the patient resource itself is edited

--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ FQM-Testify is a React-based web application for analyzing FHIR-based electronic
 
 After starting up the app, begin by uploading a FHIR Measure Bundle JSON file from your local machine. The measurement period start and end pickers will update to reflect the `effectivePeriod` of the Measure resource in the uploaded bundle. There are two methods for adding test patients to the test case: in-app patient creation and Patient Bundle import.
 
+#### Adding ValueSets to FHIR Measure Bundle
+
+The user will see an error when uploading a FHIR Measure Bundle unless it has the following things: one measure resource, all dependent library resources used, and all ValueSets needed for measure calculation. If the Measure Bundle is missing ValueSets, then the user can add ValueSets by running [the fqm-execution library](https://github.com/projecttacoma/fqm-execution) CLI with the following command:
+
+```bash
+./src/cli.ts valueSets -m <path to measure bundle> --vs-api-key <api key>
+```
+
+If you don't have a VSAC API key, look at the [fqm-execution README](https://github.com/projecttacoma/fqm-execution#valuesets) on how to get one.
+
 #### Creating a Test Patient
 
 Test patients can be created in the app by clicking on the "Create" button in the left panel. This opens a code editor modal with a pre-populated, randomly-generated FHIR Patient. The test patient can be edited from the modal and saved for future use.

--- a/__tests__/components/utils/MeasureUploadHeader.test.tsx
+++ b/__tests__/components/utils/MeasureUploadHeader.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { RouterContext } from 'next/dist/shared/lib/router-context';
+import MeasureUploadHeader from '../../../components/utils/MeasureUploadHeader';
+import { createMockRouter, mantineRecoilWrap } from '../../helpers/testHelpers';
+
+describe('MeasureUploadHeader', () => {
+  it('renders a measure upload heading for the base url', () => {
+    render(
+      mantineRecoilWrap(
+        <RouterContext.Provider value={createMockRouter({ pathname: '/' })}>
+          <MeasureUploadHeader />
+        </RouterContext.Provider>
+      )
+    );
+
+    const measureUploadHeader = screen.getByText(/Step 1: Upload a Measure Bundle/i);
+    expect(measureUploadHeader).toBeInTheDocument();
+  });
+
+  it('renders an information popover for the base url', () => {
+    render(
+      mantineRecoilWrap(
+        <RouterContext.Provider value={createMockRouter({ pathname: '/' })}>
+          <MeasureUploadHeader />
+        </RouterContext.Provider>
+      )
+    );
+
+    expect(screen.getByLabelText(/more information/i)).toBeInTheDocument();
+  });
+});

--- a/components/utils/MeasureUploadHeader.tsx
+++ b/components/utils/MeasureUploadHeader.tsx
@@ -26,8 +26,10 @@ export default function MeasureUploadHeader() {
             <List.Item>All dependent library resources used</List.Item>
             <List.Item>
               All ValueSets needed for measure calculation (see{' '}
-              <Anchor href="https://github.com/projecttacoma/fqm-testify#adding-test-cases">here</Anchor> for more info
-              on how to obtain necessary ValueSets)
+              <Anchor href="https://github.com/projecttacoma/fqm-testify#adding-valuesets-to-fhir-measure-bundle">
+                here
+              </Anchor>{' '}
+              for more info on how to obtain necessary ValueSets)
             </List.Item>
           </List>
         </Popover>

--- a/components/utils/MeasureUploadHeader.tsx
+++ b/components/utils/MeasureUploadHeader.tsx
@@ -22,7 +22,7 @@ export default function MeasureUploadHeader() {
         >
           The uploaded Measure Bundle must contain:
           <List>
-            <List.Item>One measure resource</List.Item>
+            <List.Item>Exactly one measure resource</List.Item>
             <List.Item>All dependent library resources used</List.Item>
             <List.Item>
               All ValueSets needed for measure calculation (see{' '}

--- a/components/utils/MeasureUploadHeader.tsx
+++ b/components/utils/MeasureUploadHeader.tsx
@@ -1,4 +1,4 @@
-import { Text, Popover, List, Anchor, ActionIcon } from '@mantine/core';
+import { Text, Popover, List, Anchor, ActionIcon, Group } from '@mantine/core';
 import React, { useState } from 'react';
 import { InfoCircle } from 'tabler-icons-react';
 
@@ -6,15 +6,7 @@ export default function MeasureUploadHeader() {
   const [opened, setOpened] = useState(false);
 
   return (
-    <div
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        height: '100%',
-        width: '100%',
-        padding: 20
-      }}
-    >
+    <Group>
       <div style={{ paddingRight: 5 }}>
         <Text size="xl">Step 1: Upload a Measure Bundle</Text>
       </div>
@@ -30,16 +22,16 @@ export default function MeasureUploadHeader() {
         >
           The uploaded Measure Bundle must contain:
           <List>
-            <List.Item>one measure resource</List.Item>
-            <List.Item>all dependent library resources used</List.Item>
+            <List.Item>One measure resource</List.Item>
+            <List.Item>All dependent library resources used</List.Item>
             <List.Item>
-              all ValueSets needed for measure calculation see{' '}
+              All ValueSets needed for measure calculation (see{' '}
               <Anchor href="https://github.com/projecttacoma/fqm-testify#adding-test-cases">here</Anchor> for more info
-              on how to obtain necessary ValueSets
+              on how to obtain necessary ValueSets)
             </List.Item>
           </List>
         </Popover>
       </div>
-    </div>
+    </Group>
   );
 }

--- a/components/utils/MeasureUploadHeader.tsx
+++ b/components/utils/MeasureUploadHeader.tsx
@@ -1,0 +1,45 @@
+import { Text, Popover, List, Anchor, ActionIcon } from '@mantine/core';
+import React, { useState } from 'react';
+import { InfoCircle } from 'tabler-icons-react';
+
+export default function MeasureUploadHeader() {
+  const [opened, setOpened] = useState(false);
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        height: '100%',
+        width: '100%',
+        padding: 20
+      }}
+    >
+      <div style={{ paddingRight: 5 }}>
+        <Text size="xl">Step 1: Upload a Measure Bundle</Text>
+      </div>
+      <div>
+        <Popover
+          opened={opened}
+          onClose={() => setOpened(false)}
+          target={
+            <ActionIcon aria-label={'More Information'} onClick={() => setOpened(o => !o)}>
+              <InfoCircle size={20} />
+            </ActionIcon>
+          }
+        >
+          The uploaded Measure Bundle must contain:
+          <List>
+            <List.Item>one measure resource</List.Item>
+            <List.Item>all dependent library resources used</List.Item>
+            <List.Item>
+              all ValueSets needed for measure calculation see{' '}
+              <Anchor href="https://github.com/projecttacoma/fqm-testify#adding-test-cases">here</Anchor> for more info
+              on how to obtain necessary ValueSets
+            </List.Item>
+          </List>
+        </Popover>
+      </div>
+    </div>
+  );
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,12 +2,12 @@ import type { NextPage } from 'next';
 import Link from 'next/link';
 import Head from 'next/head';
 import { Button, Grid } from '@mantine/core';
-
 import MeasureUpload from '../components/measure-upload/MeasureUpload';
 import DateSelectors from '../components/measure-upload/DateSelectors';
 import { measureBundleState } from '../state/atoms/measureBundle';
 import { measurementPeriodState } from '../state/atoms/measurementPeriod';
 import { useRecoilValue } from 'recoil';
+import MeasureUploadHeader from '../components/utils/MeasureUploadHeader';
 
 const Home: NextPage = () => {
   const measureBundle = useRecoilValue(measureBundleState);
@@ -18,6 +18,9 @@ const Home: NextPage = () => {
         <title>FQM Testify: an eCQM Analysis Tool</title>
       </Head>
       <Grid>
+        <Grid.Col span={12}>
+          <MeasureUploadHeader />
+        </Grid.Col>
         <Grid.Col span={12}>
           <MeasureUpload />
         </Grid.Col>


### PR DESCRIPTION
# Summary
The README as well as the app now include more information on what the uploaded measure bundle should contain as well as instructions on how to add ValueSets to a measure bundle through the fqm-execution CLI. 

## New Behavior
- The first page of the app where the user uploads a measure bundle now includes a sub-header to the main `AppHeader` called the `MeasureUploadHeader`. This will contain more information in the future, but for now it says "Step 1: Upload a Measure Bundle" as well as a popover button next to that text that displays more information about the measure bundle when clicked. 

## Code Changes
- `README.md` - specifications for what the uploaded measure bundle must contain and instructions on how to use the fqm-execution in order to add ValueSets to a measure bundle.
- `MeasureUploadHeader.tsx` - a sub-header component that is only displayed on the first page of the app and contains the measure upload information popover.
- `index.tsx` - renders the `MeasureUploadHeader` on the homepage.
- `MeasureUploadHeader.test.tsx` - tests that the header title and information popover are rendered.

# Testing Guidance
1. Run `npm run test`
2. Make sure that the `MeasureUploadHeader` is only rendered on the first page
3. Check spelling, grammar, missing information etc. in the `README.md` as well as the information popover in the app.
4. Let me know if you have any ideas or suggestions on anything!