### PR TITLE
Fix select box not blurring on modal close

### DIFF
--- a/__tests__/components/resource-creation/ResourceSelection.test.tsx
+++ b/__tests__/components/resource-creation/ResourceSelection.test.tsx
@@ -154,7 +154,7 @@ describe('ResourceSelection', () => {
     const resourceSelector = screen.getByPlaceholderText(/select fhir resource/i) as HTMLInputElement;
 
     await act(async () => {
-      fireEvent.focus(resourceSelector);
+      fireEvent.click(resourceSelector);
     });
 
     expect(screen.getByText(/observation/i)).toBeInTheDocument();

--- a/components/resource-creation/ResourceSelection.tsx
+++ b/components/resource-creation/ResourceSelection.tsx
@@ -5,7 +5,7 @@ import { patientTestCaseState } from '../../state/atoms/patientTestCase';
 import { valueSetMapState } from '../../state/selectors/valueSetsMap';
 import { dataRequirementsState } from '../../state/selectors/dataRequirements';
 import { selectedDataRequirementState } from '../../state/atoms/selectedDataRequirement';
-import React, { forwardRef, useRef } from 'react';
+import React, { forwardRef, useState } from 'react';
 import DataRequirementSelectOption from '../utils/DataRequirementSelectOption';
 import {
   dataRequirementsLookupState,
@@ -37,14 +37,15 @@ export default function ResourceSelection() {
   const currentPatients = useRecoilValue(patientTestCaseState);
   const dataRequirementsLookup = useRecoilValue(dataRequirementsLookupState);
 
-  const drSelectRef = useRef<HTMLInputElement>(null);
+  // Used to conditionally change the searchable prop of the select box
+  // Prevents a bug where the searchable prop caused dropdown to stay open after modal close
+  const [enableSearch, setEnableSearch] = useState(false);
 
   return dataRequirements?.length && Object.keys(currentPatients).length > 0 ? (
     <div>
       <Select
-        ref={drSelectRef}
+        searchable={enableSearch}
         maxDropdownHeight={500}
-        searchable
         placeholder="Select FHIR Resource (from Data Requirements)"
         value=""
         data={
@@ -60,11 +61,12 @@ export default function ResourceSelection() {
         onChange={val => {
           if (val) {
             const dr = dataRequirementsLookup[val];
-            if (drSelectRef.current) {
-              drSelectRef.current.blur();
-              setSelectedDataRequirement({ name: val, content: dr });
-            }
+            setSelectedDataRequirement({ name: val, content: dr });
+            setEnableSearch(false);
           }
+        }}
+        onDropdownOpen={() => {
+          setEnableSearch(true);
         }}
         itemComponent={DataRequirementSelectItem}
       />


### PR DESCRIPTION
# Summary

Fixes a bug where the resource selection dropdown remained open after closing the resource modal (via either "Save" or "Cancel").

This ended up being an issue with the `searchable` prop. For whatever reason, the combo of using `value=""` and `searchable` caused this bug. The workaround I went with for this is to only enable the searchable prop when the dropdown is open.

## New Behavior

Dropdown stays closed when modal closes

## Code Changes

* Use local state variable for whether or not to enable searching in the dropdown (flips to true when the dropdown is opened by the user)
* Update unit test to use a click instead of a focus to ensure the above functionality triggers

# Testing Guidance

* Add resource via dropdown (make sure you can still search)
* When either canceling or saving the resource, the dropdown should stay closed