### PR TITLE
Measure report state

### DIFF
--- a/components/TestCaseEditor.tsx
+++ b/components/TestCaseEditor.tsx
@@ -23,11 +23,35 @@ const useStyles = createStyles({
     overflow: 'scroll'
   }
 });
+function LoadingSpinner() {
+  const isCalculationLoading = useRecoilValue(calculationLoading);
+
+  return (
+    <>
+      <Center style={{ paddingRight: 20 }}>
+        {isCalculationLoading ? (
+          <Center>
+            <Loader size={40} />
+            <Text color="dimmed">
+              <i>Calculating...</i>
+            </Text>
+          </Center>
+        ) : (
+          <Center>
+            <CircleCheck color="green" size={40} />
+            <Text color="dimmed">
+              <i>Up to date</i>
+            </Text>
+          </Center>
+        )}
+      </Center>
+    </>
+  );
+}
 
 export default function TestCaseEditor() {
   const selectedPatient = useRecoilValue(selectedPatientState);
   const currentPatients = useRecoilValue(patientTestCaseState);
-  const isCalculationLoading = useRecoilValue(calculationLoading);
   const { classes } = useStyles();
 
   const renderPanelPlaceholderText = () => {
@@ -62,23 +86,7 @@ export default function TestCaseEditor() {
                 <Grid.Col span={4}>
                   Patient Calculation: {getPatientNameString(currentPatients[selectedPatient].patient)}
                 </Grid.Col>
-                <Center style={{ paddingRight: 20 }}>
-                  {isCalculationLoading ? (
-                    <Center>
-                      <Loader size={40} />
-                      <Text color="dimmed">
-                        <i>Calculating...</i>
-                      </Text>
-                    </Center>
-                  ) : (
-                    <Center>
-                      <CircleCheck color="green" size={40} />
-                      <Text color="dimmed">
-                        <i>Up to date</i>
-                      </Text>
-                    </Center>
-                  )}
-                </Center>
+                <LoadingSpinner />
               </Grid>
             ) : (
               renderPanelPlaceholderText()

--- a/components/calculation/MeasureHighlightingPanel.tsx
+++ b/components/calculation/MeasureHighlightingPanel.tsx
@@ -1,7 +1,7 @@
 import { createStyles } from '@mantine/core';
 import { useRecoilValue } from 'recoil';
 import parse from 'html-react-parser';
-import { patientTestCaseState } from '../../state/atoms/patientTestCase';
+import { measureReportLookupState } from '../../state/atoms/measureReportLookup';
 
 const useStyles = createStyles({
   highlightedMarkup: {
@@ -20,14 +20,12 @@ export interface MeasureHighlightingPanelProps {
 }
 
 export default function MeasureHighlightingPanel({ patientId }: MeasureHighlightingPanelProps) {
-  const currentPatients = useRecoilValue(patientTestCaseState);
   const { classes } = useStyles();
+  const measureReportLookup = useRecoilValue(measureReportLookupState);
 
   return (
     <>
-      <div className={classes.highlightedMarkup}>
-        {parse(currentPatients[patientId].measureReport?.text?.div || '')}
-      </div>
+      <div className={classes.highlightedMarkup}>{parse(measureReportLookup[patientId].text?.div || '')}</div>
     </>
   );
 }

--- a/components/calculation/MeasureHighlightingPanel.tsx
+++ b/components/calculation/MeasureHighlightingPanel.tsx
@@ -25,7 +25,7 @@ export default function MeasureHighlightingPanel({ patientId }: MeasureHighlight
 
   return (
     <>
-      <div className={classes.highlightedMarkup}>{parse(measureReportLookup[patientId].text?.div || '')}</div>
+      <div className={classes.highlightedMarkup}>{parse(measureReportLookup[patientId]?.text?.div || '')}</div>
     </>
   );
 }

--- a/components/patient-creation/PatientCreationPanel.tsx
+++ b/components/patient-creation/PatientCreationPanel.tsx
@@ -119,30 +119,32 @@ function PatientCreationPanel() {
       setCurrentPatients(nextPatientState);
       setIsCalculationLoading(true);
 
-      produce(measureReportLookup, async draftState => {
-        if (measureBundle.content) {
-          try {
-            draftState[patientId] = await calculateMeasureReport(
-              nextPatientState[patientId],
-              measureBundle.content,
-              measurementPeriod.start?.toISOString(),
-              measurementPeriod.end?.toISOString()
-            );
-          } catch (error) {
-            if (error instanceof Error) {
-              showNotification({
-                icon: <IconAlertCircle />,
-                title: 'Calculation Error',
-                message: error.message,
-                color: 'red'
-              });
+      setTimeout(() => {
+        produce(measureReportLookup, async draftState => {
+          if (measureBundle.content) {
+            try {
+              draftState[patientId] = await calculateMeasureReport(
+                nextPatientState[patientId],
+                measureBundle.content,
+                measurementPeriod.start?.toISOString(),
+                measurementPeriod.end?.toISOString()
+              );
+            } catch (error) {
+              if (error instanceof Error) {
+                showNotification({
+                  icon: <IconAlertCircle />,
+                  title: 'Calculation Error',
+                  message: error.message,
+                  color: 'red'
+                });
+              }
             }
           }
-        }
-      }).then(nextMRLookupState => {
-        setMeasureReportLookup(nextMRLookupState);
-        setIsCalculationLoading(false);
-      });
+        }).then(nextMRLookupState => {
+          setMeasureReportLookup(nextMRLookupState);
+          setIsCalculationLoading(false);
+        });
+      }, 400);
     }
 
     closePatientModal();

--- a/components/patient-creation/PatientCreationPanel.tsx
+++ b/components/patient-creation/PatientCreationPanel.tsx
@@ -161,7 +161,11 @@ function PatientCreationPanel() {
       const nextPatientState = produce(currentPatients, draftState => {
         delete draftState[id];
       });
+      const nextResourceState = produce(measureReportLookup, draftState => {
+        delete draftState[id];
+      });
       setCurrentPatients(nextPatientState);
+      setMeasureReportLookup(nextResourceState);
       // Set the selected patient to null because the selected patient will not longer exist after it is deleted
       setSelectedPatient(null);
       closeConfirmationModal();

--- a/components/patient-creation/PatientCreationPanel.tsx
+++ b/components/patient-creation/PatientCreationPanel.tsx
@@ -64,14 +64,15 @@ function PatientCreationPanel() {
   };
 
   const measureReportCalculation = async (id: string) => {
-    if (!currentPatients[id].measureReport) {
+    setSelectedPatient(id);
+    if (!measureReportLookup[id]) {
       setIsCalculationLoading(true);
       // Create a new state object using immer without needing to shallow clone the entire previous object
-      produce(currentPatients, async draftState => {
+      produce(measureReportLookup, async draftState => {
         if (measureBundle.content) {
           try {
-            draftState[id].measureReport = await calculateMeasureReport(
-              draftState[id],
+            draftState[id] = await calculateMeasureReport(
+              currentPatients[id],
               measureBundle.content,
               measurementPeriod.start?.toISOString(),
               measurementPeriod.end?.toISOString()
@@ -87,8 +88,8 @@ function PatientCreationPanel() {
             }
           }
         }
-      }).then(nextPatientState => {
-        setCurrentPatients(nextPatientState);
+      }).then(nextMRLookupState => {
+        setMeasureReportLookup(nextMRLookupState);
         setIsCalculationLoading(false);
       });
     }

--- a/components/resource-creation/ResourceDisplay.tsx
+++ b/components/resource-creation/ResourceDisplay.tsx
@@ -108,8 +108,6 @@ function ResourceDisplay() {
   };
 
   const updateResource = (val: string) => {
-    closeResourceModal();
-
     const updatedResource = JSON.parse(val.trim());
     if (updatedResource.id) {
       const resourceId = updatedResource.id;
@@ -139,11 +137,10 @@ function ResourceDisplay() {
         }, 400);
       }
     }
+    closeResourceModal();
   };
 
   const deleteResource = (id: string | null) => {
-    closeConfirmationModal();
-
     if (id && selectedPatient) {
       const resourceIndexToDelete = currentTestCases[selectedPatient].resources.findIndex(r => r.id === id);
       const nextResourceState = produce(currentTestCases, draftState => {
@@ -163,6 +160,7 @@ function ResourceDisplay() {
         });
       }, 400);
     }
+    closeConfirmationModal();
   };
 
   const getInitialResource = () => {

--- a/components/resource-creation/ResourceDisplay.tsx
+++ b/components/resource-creation/ResourceDisplay.tsx
@@ -108,7 +108,6 @@ function ResourceDisplay() {
   };
 
   const updateResource = (val: string) => {
-    setIsResourceModalOpen(false);
     closeResourceModal();
 
     const updatedResource = JSON.parse(val.trim());
@@ -130,12 +129,14 @@ function ResourceDisplay() {
         setCurrentTestCases(nextResourceState);
         setIsCalculationLoading(true);
 
-        produce(measureReportLookup, async draftState => {
-          await measureReportCalculation(draftState, selectedPatient, nextResourceState);
-        }).then(nextMRLookupState => {
-          setMeasureReportLookup(nextMRLookupState);
-          setIsCalculationLoading(false);
-        });
+        setTimeout(() => {
+          produce(measureReportLookup, async draftState => {
+            await measureReportCalculation(draftState, selectedPatient, nextResourceState);
+          }).then(nextMRLookupState => {
+            setMeasureReportLookup(nextMRLookupState);
+            setIsCalculationLoading(false);
+          });
+        }, 400);
       }
     }
   };
@@ -153,12 +154,14 @@ function ResourceDisplay() {
       setCurrentTestCases(nextResourceState);
       setIsCalculationLoading(true);
 
-      produce(measureReportLookup, async draftState => {
-        await measureReportCalculation(draftState, selectedPatient, nextResourceState);
-      }).then(nextMRLookupState => {
-        setMeasureReportLookup(nextMRLookupState);
-        setIsCalculationLoading(false);
-      });
+      setTimeout(() => {
+        produce(measureReportLookup, async draftState => {
+          await measureReportCalculation(draftState, selectedPatient, nextResourceState);
+        }).then(nextMRLookupState => {
+          setMeasureReportLookup(nextMRLookupState);
+          setIsCalculationLoading(false);
+        });
+      }, 400);
     }
   };
 

--- a/components/resource-creation/ResourcePanel.tsx
+++ b/components/resource-creation/ResourcePanel.tsx
@@ -51,33 +51,35 @@ export default function ResourcePanel() {
         setCurrentPatients(nextResourceState);
         setIsCalculationLoading(true);
 
-        produce(measureReportLookup, async draftState => {
-          if (measureBundle.content) {
-            try {
-              draftState[selectedPatient] = await calculateMeasureReport(
-                nextResourceState[selectedPatient],
-                measureBundle.content,
-                measurementPeriod.start?.toISOString(),
-                measurementPeriod.end?.toISOString()
-              );
-            } catch (error) {
-              if (error instanceof Error) {
-                showNotification({
-                  icon: <IconAlertCircle />,
-                  title: 'Calculation Error',
-                  message: error.message,
-                  color: 'red'
-                });
+        setTimeout(() => {
+          produce(measureReportLookup, async draftState => {
+            if (measureBundle.content) {
+              try {
+                draftState[selectedPatient] = await calculateMeasureReport(
+                  nextResourceState[selectedPatient],
+                  measureBundle.content,
+                  measurementPeriod.start?.toISOString(),
+                  measurementPeriod.end?.toISOString()
+                );
+              } catch (error) {
+                if (error instanceof Error) {
+                  showNotification({
+                    icon: <IconAlertCircle />,
+                    title: 'Calculation Error',
+                    message: error.message,
+                    color: 'red'
+                  });
+                }
               }
             }
-          }
-        }).then(nextMRLookupState => {
-          setMeasureReportLookup(nextMRLookupState);
-          setIsCalculationLoading(false);
-          setIsNewResourceModalOpen(false);
-        });
+          }).then(nextMRLookupState => {
+            setMeasureReportLookup(nextMRLookupState);
+            setIsCalculationLoading(false);
+          });
+        }, 400);
       }
     }
+    setIsNewResourceModalOpen(false);
   };
 
   const renderPanelPlaceholderText = () => {

--- a/pages/generate-test-cases.tsx
+++ b/pages/generate-test-cases.tsx
@@ -12,22 +12,24 @@ import produce from 'immer';
 import { calculationLoading } from '../state/atoms/calculationLoading';
 import { showNotification } from '@mantine/notifications';
 import { IconAlertCircle } from '@tabler/icons';
+import { measureReportLookupState } from '../state/atoms/measureReportLookup';
 
 const TestCaseEditorPage: NextPage = () => {
   const { start, end } = useRecoilValue(measurementPeriodState);
   const measureBundle = useRecoilValue(measureBundleState);
-  const [currentPatients, setCurrentPatients] = useRecoilState(patientTestCaseState);
+  const currentPatients = useRecoilValue(patientTestCaseState);
   const setIsCalculationLoading = useSetRecoilState(calculationLoading);
+  const [measureReportLookup, setMeasureReportLookup] = useRecoilState(measureReportLookupState);
 
   // re-runs the measureReport calculation whenever the user navigates to the generate-test-cases page
   useEffect(() => {
     if (measureBundle.content) {
       const mb = measureBundle.content;
       setIsCalculationLoading(true);
-      produce(currentPatients, async draftState => {
+      produce(measureReportLookup, async draftState => {
         for (const [patientId, testCaseInfo] of Object.entries(currentPatients)) {
           try {
-            draftState[patientId].measureReport = await calculateMeasureReport(
+            draftState[patientId] = await calculateMeasureReport(
               testCaseInfo,
               mb,
               start?.toISOString(),
@@ -44,8 +46,8 @@ const TestCaseEditorPage: NextPage = () => {
             }
           }
         }
-      }).then(nextPatientState => {
-        setCurrentPatients(nextPatientState);
+      }).then(nextMRLookupState => {
+        setMeasureReportLookup(nextMRLookupState);
         setIsCalculationLoading(false);
       });
     }

--- a/state/atoms/measureReportLookup.ts
+++ b/state/atoms/measureReportLookup.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const measureReportLookupState = atom<Record<string, fhir4.MeasureReport>>({
+  key: 'measureReportLookupState',
+  default: {}
+});

--- a/state/atoms/patientTestCase.ts
+++ b/state/atoms/patientTestCase.ts
@@ -3,7 +3,6 @@ import { atom } from 'recoil';
 export interface TestCaseInfo {
   patient: fhir4.Patient;
   resources: fhir4.FhirResource[];
-  measureReport?: fhir4.MeasureReport;
 }
 
 export interface TestCase {


### PR DESCRIPTION
# Summary
Before, the measure report for a patient was a property on the patient's state. Now, we can access the measure report for the patient by accessing it by a different state. 

## New Behavior
There is now a new atom for measureReportLookup, so all of the places where calculation takes place were updated to use the new state, but all other behavior remains the same.

## Code Changes
- `measureReportLookup.ts` - creates a new atom for measureReportLookup.
- `MeasureHighlightingPanel.tsx` - Now parses the measure report that is in the measureReportLookup atom.
- `PatientCreationPanel.tsx` - Updated all the places where calculation takes place to use the same state.
- `ResourceDisplay.tsx` - Updated all the places where calculation takes place to use the same state. Also gets rid of the `setTimeout()`.
- `ResourcePanel.tsx` - Updated all the places where calculation takes place to use the same state. 
- `generate-test-cases.ts` - Updated all the places where calculation takes place to use the same state.

# Testing Guidance
1. Run `npm run check` to ensure that all tests still pass and that there are no lint or prettier errors. 
2. Make sure that the measure highlighting changes in the following cases:
- The measurement period is edited
- The measure bundle is changed
- A test case is imported
- A test case is edited
- A test resource is added to a test case
- A test resource is edited
- A test resource is deleted