### PR TITLE
Add dropdown for selecting desired populations

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ Test patients can be created in the app by clicking on the "Create" button in th
 
 Test cases can be imported by clicking the "Import" button in the left panel, which will open a file dropzone that accepts JSON files of FHIR Patient Bundles and `.zip` files composed of FHIR Patient Bundles. Patient Bundles may contain additional FHIR resources. These FHIR resources are also loaded into the app and will belong to the patient contained in the Patient Bundle.
 
+#### Selecting Desired Measure Populations
+
+For each test patient, the user has the option to select the population(s) for which the patient should belong during testing. Use the dropdown to select the desired population(s). See the [eCQM documentation on population criteria](https://build.fhir.org/ig/HL7/cqf-measures/measure-conformance.html#population-criteria) for more information.
+
 #### Creating Non-Patient Test Resources
 
 FQM-Testify allows the user to create non-patient FHIR resources after at least one patient resource is created in or imported to the app. To create a FHIR resource for a test patient, first select the test patient from the left panel. Once selected, FHIR resources can be created from the middle panel in two ways.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Test cases can be imported by clicking the "Import" button in the left panel, wh
 
 #### Selecting Desired Measure Populations
 
-For each test patient, the user has the option to select the population(s) for which the patient should belong during testing. Use the dropdown to select the desired population(s). See the [eCQM documentation on population criteria](https://build.fhir.org/ig/HL7/cqf-measures/measure-conformance.html#population-criteria) for more information.
+For each test patient, the user has the option to select the population(s) for which the patient should belong during measure calculation. Use the dropdown on the selected patient's information card to select the desired population(s). See the [eCQM documentation on population criteria](https://build.fhir.org/ig/HL7/cqf-measures/measure-conformance.html#population-criteria) for more information.
 
 #### Creating Non-Patient Test Resources
 

--- a/__tests__/components/utils/PopulationMultiSelect.test.tsx
+++ b/__tests__/components/utils/PopulationMultiSelect.test.tsx
@@ -104,7 +104,7 @@ describe('PopulationMultiSelect', () => {
     expect(populationSelector).toBeInTheDocument();
   });
 
-  it('should show populations as options', async () => {
+  it('should show population from measure group as a dropdown option', async () => {
     window.ResizeObserver = mockResizeObserver;
     const MockMB = getMockRecoilState(measureBundleState, MEASURE_BUNDLE_POPULATED);
     const MockPatients = getMockRecoilState(patientTestCaseState, MOCK_TEST_CASE);
@@ -125,15 +125,15 @@ describe('PopulationMultiSelect', () => {
       );
     });
 
-    const autocomplete = screen.getByRole('combobox');
-    const input = within(autocomplete).getByRole('searchbox');
-    autocomplete.focus();
+    const multiselect = screen.getByRole('combobox');
+    const input = within(multiselect).getByRole('searchbox');
+    multiselect.focus();
 
-    //mocks user key clicks to test the input fields and drop down menus
+    // mock user key clicks to test input fields and drop down menus
     await act(async () => {
       fireEvent.change(input, { target: { value: 'D' } });
-      fireEvent.keyDown(autocomplete, { key: 'ArrowDown' });
-      fireEvent.keyDown(autocomplete, { key: 'Enter' });
+      fireEvent.keyDown(multiselect, { key: 'ArrowDown' });
+      fireEvent.keyDown(multiselect, { key: 'Enter' });
     });
 
     expect(screen.getByText(/denominator/i)).toBeInTheDocument();

--- a/__tests__/components/utils/PopulationMultiSelect.test.tsx
+++ b/__tests__/components/utils/PopulationMultiSelect.test.tsx
@@ -1,0 +1,115 @@
+import '@testing-library/jest-dom';
+import { act, render, screen, fireEvent, within } from '@testing-library/react';
+import { Suspense } from 'react';
+import PatientCreationPanel from '../../../components/patient-creation/PatientCreationPanel';
+import PatientInfoCard, { PatientInfoCardProps } from '../../../components/utils/PatientInfoCard';
+import PopulationMultiSelect from '../../../components/utils/PopulationMultiSelect';
+import { measureBundleState } from '../../../state/atoms/measureBundle';
+import { patientTestCaseState, TestCase } from '../../../state/atoms/patientTestCase';
+import { selectedPatientState } from '../../../state/atoms/selectedPatient';
+import { getMockRecoilState, mantineRecoilWrap } from '../../helpers/testHelpers';
+
+const TEST_MEASURE_BUNDLE: fhir4.Bundle = {
+  resourceType: 'Bundle',
+  type: 'transaction',
+  entry: [
+    {
+      resource: {
+        resourceType: 'Measure',
+        status: 'active',
+        group: [
+          {
+            population: [
+              {
+                code: {
+                  coding: [
+                    {
+                      system: 'test-system',
+                      code: 'denominator',
+                      display: 'Denominator'
+                    }
+                  ]
+                },
+                criteria: {
+                  language: 'text/cql.identifier',
+                  expression: 'Denominator'
+                }
+              },
+              {
+                code: {
+                  coding: [
+                    {
+                      system: 'test-system',
+                      code: 'numerator',
+                      display: 'Numerator'
+                    }
+                  ]
+                },
+                criteria: {
+                  language: 'text/cql.identifier',
+                  expression: 'Numerator'
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+};
+
+const MEASURE_BUNDLE_POPULATED = {
+  name: 'measureBundle',
+  content: TEST_MEASURE_BUNDLE
+};
+
+const EXAMPLE_PATIENT: fhir4.Patient = {
+  resourceType: 'Patient',
+  id: 'example-pt',
+  name: [{ given: ['Test123'], family: 'Patient456' }],
+  birthDate: '1996-07-19'
+};
+
+const MOCK_TEST_CASE: TestCase = {
+  'example-pt': {
+    patient: EXAMPLE_PATIENT,
+    resources: []
+  }
+};
+
+const MOCK_CALLBACK_PROPS: Omit<PatientInfoCardProps, 'patient'> = {
+  onEditClick: jest.fn(),
+  onDeleteClick: jest.fn(),
+  onExportClick: jest.fn(),
+  onCopyClick: jest.fn()
+};
+
+describe('PopulationMultiSelect', () => {
+  it('should show populations as options', async () => {
+    const MockMB = getMockRecoilState(measureBundleState, MEASURE_BUNDLE_POPULATED);
+    const MockPatients = getMockRecoilState(patientTestCaseState, MOCK_TEST_CASE);
+    const MockSelectedPatient = getMockRecoilState(selectedPatientState, 'example-pt');
+
+    await act(async () => {
+      render(
+        mantineRecoilWrap(
+          <>
+            <MockMB />
+            <PopulationMultiSelect />
+          </>
+        )
+      );
+    });
+
+    const populationSelector = screen.getByPlaceholderText(/select populations/i) as HTMLInputElement;
+    await act(async () => {
+      fireEvent.click(populationSelector);
+    });
+
+    // const options = screen.getAllByRole('option');
+    // expect(options[0].textContent).toBe('denominator');
+
+    //expect(within(populationSelector).getByText(/denominator/i)).toBeInTheDocument();
+    //expect(screen.getByText(/numerator/i)).toBeInTheDocument();
+  });
+});

--- a/__tests__/helpers/testHelpers.tsx
+++ b/__tests__/helpers/testHelpers.tsx
@@ -73,3 +73,9 @@ export function createMockRouter(router: Partial<NextRouter>): NextRouter {
     ...router
   };
 }
+
+export const mockResizeObserver = jest.fn().mockImplementation(() => ({
+  observe: jest.fn(),
+  unobserve: jest.fn(),
+  disconnect: jest.fn()
+}));

--- a/components/utils/PatientInfoCard.tsx
+++ b/components/utils/PatientInfoCard.tsx
@@ -2,6 +2,7 @@ import { Button, Center, Divider, Grid, Paper, Sx, Text, Tooltip } from '@mantin
 import React from 'react';
 import { Copy, Download, Edit, Trash } from 'tabler-icons-react';
 import { getPatientDOBString, getPatientNameString } from '../../util/fhir';
+import PopulationMultiSelect from './PopulationMultiSelect';
 
 export interface PatientInfoCardProps {
   patient: fhir4.Patient;
@@ -106,6 +107,7 @@ export default function PatientInfoCard({
           </Center>
         </Grid.Col>
       </Grid>
+      {selected && <PopulationMultiSelect />}
     </Paper>
   );
 }

--- a/components/utils/PopulationMultiSelect.tsx
+++ b/components/utils/PopulationMultiSelect.tsx
@@ -70,8 +70,9 @@ export default function PopulationMultiSelect() {
    * @param value array of selected options from MultiSelect component
    */
   const updateDesiredPopulations = (value: string[]) => {
-    const newDesiredPopulations = value;
+    let newDesiredPopulations = [...value];
     if (selectedPatient) {
+
       // add initial population since it is a superset of all other populations
       if (value.length > 0 && !value.includes(Enums.PopulationType.IPP)) {
         newDesiredPopulations.push(Enums.PopulationType.IPP);
@@ -84,6 +85,25 @@ export default function PopulationMultiSelect() {
         !value.includes(Enums.PopulationType.DENOM)
       ) {
         newDesiredPopulations.push(Enums.PopulationType.DENOM);
+      }
+
+      // remove all selected populations if initial population is deselected
+      if (
+        currentPatients[selectedPatient].desiredPopulations?.includes(Enums.PopulationType.IPP) &&
+        !value.includes(Enums.PopulationType.IPP)
+      ) {
+        newDesiredPopulations = [];
+      }
+      // remove numerator, numerator exclusion, and/or denominator exception if denominator is deselected
+      if (
+        [Enums.PopulationType.NUMER, Enums.PopulationType.NUMEX, Enums.PopulationType.DENEXCEP].some(p =>
+          currentPatients[selectedPatient].desiredPopulations?.includes(p)
+        ) &&
+        !value.includes(Enums.PopulationType.DENOM)
+      ) {
+        newDesiredPopulations = newDesiredPopulations.filter(
+          p => p === Enums.PopulationType.IPP || p === Enums.PopulationType.DENEX
+        );
       }
 
       // update the desired populations state

--- a/components/utils/PopulationMultiSelect.tsx
+++ b/components/utils/PopulationMultiSelect.tsx
@@ -1,5 +1,7 @@
 import { MultiSelect, Text } from '@mantine/core';
 import produce from 'immer';
+import { Enums } from 'fqm-execution';
+import { useState } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { measureBundleState } from '../../state/atoms/measureBundle';
 import { patientTestCaseState } from '../../state/atoms/patientTestCase';
@@ -8,10 +10,12 @@ import { selectedPatientState } from '../../state/atoms/selectedPatient';
 interface MultiSelectData {
   value: string;
   label: string;
+  disabled: boolean;
 }
 export default function PopulationMultiSelect() {
   const measureBundle = useRecoilValue(measureBundleState);
   const [currentPatients, setCurrentPatients] = useRecoilState(patientTestCaseState);
+  const [value, setValue] = useState<string[]>([]);
   const selectedPatient = useRecoilValue(selectedPatientState);
   const measure = measureBundle.content?.entry?.find(e => e.resource?.resourceType === 'Measure')?.resource;
 
@@ -21,35 +25,101 @@ export default function PopulationMultiSelect() {
    * @param {fhir4.Measure} measure - FHIR measure resource
    * @returns {Array} array of strings representing all measure populations
    */
-  function getMeasurePopulations(measure: fhir4.Measure) {
+  const getMeasurePopulations = (measure: fhir4.Measure): Array<MultiSelectData> => {
     const measurePopulations: MultiSelectData[] = [];
     // Iterate over measure population groups
     measure.group?.forEach(group => {
       group.population?.forEach(population => {
         const populationCode = population.code?.coding?.[0].code;
         const populationDisplay = population.code?.coding?.[0].display;
-        if (populationCode && !measurePopulations.map(p => p.value).includes(populationCode)) {
-          measurePopulations.push({ value: populationCode, label: populationDisplay || populationCode });
+        if (
+          populationCode &&
+          !measurePopulations.map(p => p.value).includes(populationCode) &&
+          !['measure-population', 'measure-population-exclusion', 'measure-observation'].includes(populationCode)
+        ) {
+          measurePopulations.push({
+            value: populationCode,
+            label: populationDisplay || populationCode,
+            disabled: false
+          });
         }
       });
     });
     return measurePopulations;
-  }
+  };
 
-  function updateDesiredPopulations(value: string[]){
-    console.log(value);
+  const updateDesiredPopulations = (value: string[]) => {
+    const newDesiredPopulations = value;
     if (selectedPatient) {
+      // add intiial population since it is a superset of all other populations
+      if (value.length > 0 && !value.includes(Enums.PopulationType.IPP)) {
+        newDesiredPopulations.push(Enums.PopulationType.IPP);
+      }
+      // add denominator if numerator, numer exclusion, or denom exception are selected
+      if (
+        [Enums.PopulationType.NUMER, Enums.PopulationType.NUMEX, Enums.PopulationType.DENEXCEP].some(p =>
+          value.includes(p)
+        ) &&
+        !value.includes(Enums.PopulationType.DENOM)
+      ) {
+        newDesiredPopulations.push(Enums.PopulationType.DENOM);
+      }
       produce(currentPatients, async draftState => {
-        draftState[selectedPatient].desiredPopulations = value;
+        // change this to be concatenated with whatever is needed with the logic
+        draftState[selectedPatient].desiredPopulations = newDesiredPopulations;
       }).then(nextPatientState => {
         setCurrentPatients(nextPatientState);
-      })
+      });
+      setValue(newDesiredPopulations);
     }
-    console.log(currentPatients);
-  }
+  };
+
+  const updateMeasurePopulations = (populations: MultiSelectData[]): MultiSelectData[] => {
+    // disable denominator exclusion if denominator selected
+    if (value.includes(Enums.PopulationType.DENOM)) {
+      const denex = populations.find(e => e.value === Enums.PopulationType.DENEX);
+      if (denex) denex.disabled = true;
+    }
+
+    // disable all other populations if denominator exclusion selected
+    if (value.includes(Enums.PopulationType.DENEX)) {
+      const disabledPops = populations.filter(e => e.value !== Enums.PopulationType.IPP);
+      disabledPops.forEach(pop => (pop.disabled = true));
+    }
+
+    // disable numerator exclusion, denominator exclusion, denominator exception if numerator selected
+    if (value.includes(Enums.PopulationType.NUMER)) {
+      const disabledPops = populations.filter(
+        p =>
+          p.value === Enums.PopulationType.NUMEX ||
+          p.value === Enums.PopulationType.DENEX ||
+          p.value === Enums.PopulationType.DENEXCEP
+      );
+      disabledPops.forEach(pop => (pop.disabled = true));
+    }
+
+    // disable numerator if numerator exclusion selected
+    if (value.includes(Enums.PopulationType.NUMEX)) {
+      const numer = populations.find(e => e.value === Enums.PopulationType.NUMER);
+      if (numer) numer.disabled = true;
+    }
+
+    // disable denominator exclusion, numerator, and numerator exclusion if denominator exception selected
+    if (value.includes(Enums.PopulationType.DENEXCEP)) {
+      const disabledPops = populations.filter(
+        p =>
+          p.value === Enums.PopulationType.DENEX ||
+          p.value === Enums.PopulationType.NUMER ||
+          p.value === Enums.PopulationType.NUMEX
+      );
+      disabledPops.forEach(pop => (pop.disabled = true));
+    }
+
+    return populations;
+  };
 
   if (measure) {
-    const populations = getMeasurePopulations(measure as fhir4.Measure);
+    const populations = updateMeasurePopulations(getMeasurePopulations(measure as fhir4.Measure));
     return (
       <MultiSelect
         data={populations}
@@ -58,7 +128,7 @@ export default function PopulationMultiSelect() {
         dropdownPosition="bottom"
         clearable
         onChange={updateDesiredPopulations}
-        value={selectedPatient ? currentPatients[selectedPatient].desiredPopulations : []}
+        value={value}
       />
     );
   } else {

--- a/components/utils/PopulationMultiSelect.tsx
+++ b/components/utils/PopulationMultiSelect.tsx
@@ -26,9 +26,9 @@ export default function PopulationMultiSelect() {
   const [opened, setOpened] = useState(false);
 
   /**
-   * Compiles an array of data for the MultiSelect component, using population codes 
-   * from the measure resource, across all groups in the measure. 
-   * 
+   * Compiles an array of data for the MultiSelect component, using population codes
+   * from the measure resource, across all groups in the measure.
+   *
    * Excludes measure-population, measure-population-exclusion, and measure-observation
    * (used for CV measures).
    * @param {fhir4.Measure} measure - FHIR measure resource
@@ -60,7 +60,7 @@ export default function PopulationMultiSelect() {
   };
 
   /**
-   * Sets desired populations state (for the selected patient) based on the measure 
+   * Sets desired populations state (for the selected patient) based on the measure
    * populations selected from MultiSelect component and their relevant supset populations.
    * @param value array of selected options from MultiSelect component
    */
@@ -95,12 +95,12 @@ export default function PopulationMultiSelect() {
   /**
    * Uses the selected populations from the MultiSelect component to determine which
    * populations can be selected, based on the population criteria.
-   * If a population cannot be selected in conjunction with a population that has already been selected, 
+   * If a population cannot be selected in conjunction with a population that has already been selected,
    * the population will become disabled in the dropdown.
-   * 
-   * Based on population criteria for proportion measures: 
+   *
+   * Based on population criteria for proportion measures:
    * https://build.fhir.org/ig/HL7/cqf-measures/measure-conformance.html#population-criteria
-   * 
+   *
    * @param populations all measure populations available for the measure
    * @returns array of filtered populations that can be selected
    */

--- a/components/utils/PopulationMultiSelect.tsx
+++ b/components/utils/PopulationMultiSelect.tsx
@@ -17,9 +17,12 @@ interface MultiSelectData {
 export default function PopulationMultiSelect() {
   const measureBundle = useRecoilValue(measureBundleState);
   const selectedPatient = useRecoilValue(selectedPatientState);
-  const measure = measureBundle.content?.entry?.find(e => e.resource?.resourceType === 'Measure')?.resource;
+  const measure = measureBundle.content?.entry?.find(e => e.resource?.resourceType === 'Measure')
+    ?.resource as fhir4.Measure;
   const [currentPatients, setCurrentPatients] = useRecoilState(patientTestCaseState);
-  const [value, setValue] = useState<string[]>(selectedPatient ? currentPatients[selectedPatient].desiredPopulations || []: []);
+  const [value, setValue] = useState<string[]>(
+    selectedPatient ? currentPatients[selectedPatient].desiredPopulations || [] : []
+  );
   const [opened, setOpened] = useState(false);
 
   /**
@@ -134,31 +137,36 @@ export default function PopulationMultiSelect() {
   };
 
   if (measure) {
-    const populations = updateMeasurePopulations(getMeasurePopulations(measure as fhir4.Measure));
+    const populations = updateMeasurePopulations(getMeasurePopulations(measure));
     return (
       <MultiSelect
         data={populations}
+        aria-expanded={true}
         label={
           <Group>
-          Desired Populations
-          <div>
-          <Popover opened={opened} onClose={() => setOpened(false)}>
-            <Popover.Target>
-              <ActionIcon aria-label={'More Information'} onClick={() => setOpened(o => !o)}>
-                <InfoCircle size={20} />
-              </ActionIcon>
-            </Popover.Target>
-            <Popover.Dropdown>
-              A measure population is disabled if a patient cannot belong to both the disabled population and the selected population(s).
-            </Popover.Dropdown>
-          </Popover>
-        </div></Group>}
+            Desired Populations
+            <div>
+              <Popover opened={opened} onClose={() => setOpened(false)}>
+                <Popover.Target>
+                  <ActionIcon aria-label={'More Information'} onClick={() => setOpened(o => !o)}>
+                    <InfoCircle size={20} />
+                  </ActionIcon>
+                </Popover.Target>
+                <Popover.Dropdown>
+                  A measure population is disabled if a patient cannot belong to both the disabled population and the
+                  selected population(s).
+                </Popover.Dropdown>
+              </Popover>
+            </div>
+          </Group>
+        }
         placeholder={'Select populations'}
         dropdownPosition="bottom"
+        searchable={true}
         clearable
         onChange={updateDesiredPopulations}
         value={value}
-      /> 
+      />
     );
   } else {
     return <Text>Measure populations not available</Text>;

--- a/components/utils/PopulationMultiSelect.tsx
+++ b/components/utils/PopulationMultiSelect.tsx
@@ -72,7 +72,6 @@ export default function PopulationMultiSelect() {
   const updateDesiredPopulations = (value: string[]) => {
     let newDesiredPopulations = [...value];
     if (selectedPatient) {
-
       // add initial population since it is a superset of all other populations
       if (value.length > 0 && !value.includes(Enums.PopulationType.IPP)) {
         newDesiredPopulations.push(Enums.PopulationType.IPP);

--- a/components/utils/PopulationMultiSelect.tsx
+++ b/components/utils/PopulationMultiSelect.tsx
@@ -1,0 +1,47 @@
+import { MultiSelect, Text } from '@mantine/core';
+import { useRecoilValue } from 'recoil';
+import { measureBundleState } from '../../state/atoms/measureBundle';
+
+interface MultiSelectData {
+  value: string;
+  label: string;
+}
+export default function PopulationMultiSelect() {
+  const measureBundle = useRecoilValue(measureBundleState);
+  const measure = measureBundle.content?.entry?.find(e => e.resource?.resourceType === 'Measure')?.resource;
+
+  /**
+   * Compiles an array of population codes from the measure resource,
+   * across all groups in the measure.
+   * @param {fhir4.Measure} measure - FHIR measure resource
+   * @returns {Array} array of strings representing all measure populations
+   */
+  function getMeasurePopulations(measure: fhir4.Measure) {
+    const measurePopulations: MultiSelectData[] = [];
+    // Iterate over measure population groups
+    measure.group?.forEach(group => {
+      group.population?.forEach(population => {
+        const populationCode = population.code?.coding?.[0].code;
+        const populationDisplay = population.code?.coding?.[0].display;
+        if (populationCode && !measurePopulations.map(p => p.value).includes(populationCode)) {
+          measurePopulations.push({ value: populationCode, label: populationDisplay || populationCode });
+        }
+      });
+    });
+    return measurePopulations;
+  }
+
+  if (measure) {
+    const populations = getMeasurePopulations(measure as fhir4.Measure);
+    return (
+      <MultiSelect
+        data={populations}
+        label={'Desired Populations'}
+        placeholder={'Select populations'}
+        dropdownPosition="bottom"
+      />
+    );
+  } else {
+    return <Text>Measure populations not available</Text>;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6811,7 +6811,7 @@
         "object-keys": {
           "version": "0.4.0",
           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
+          "integrity": "sha512-ncrLw+X55z7bkl5PnUvHwFK9FcGuFYo9gtjws2XtSzL+aZ8tm830P60WJ0dSmFVaSalWieW5MD7kEdnXda9yJw=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -6811,7 +6811,7 @@
         "object-keys": {
           "version": "0.4.0",
           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-          "integrity": "sha512-ncrLw+X55z7bkl5PnUvHwFK9FcGuFYo9gtjws2XtSzL+aZ8tm830P60WJ0dSmFVaSalWieW5MD7kEdnXda9yJw=="
+          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
         }
       }
     },

--- a/state/atoms/patientTestCase.ts
+++ b/state/atoms/patientTestCase.ts
@@ -3,6 +3,7 @@ import { atom } from 'recoil';
 export interface TestCaseInfo {
   patient: fhir4.Patient;
   resources: fhir4.FhirResource[];
+  desiredPopulations?: string[];
 }
 
 export interface TestCase {


### PR DESCRIPTION
# Summary
Allows the user to select the desired measure population(s) for each test patient.

## New Behavior
When a patient is selected, a dropdown with the label “Desired Populations” should appear.  The dropdown is populated with all the measure populations that appear in the measure bundle. When a user clicks on a measure population, it gets added to the test case state object. 

If a user clicks on a population, all of the population’s superset populations will also be selected. For example, if the numerator population is selected, then the denominator and initial population will also appear as selected values and will also get added to the test case state object.

Populations become disabled if they cannot be selected alongside the already selected populations. For example, if the user clicks on the numerator population, then the numerator exclusion population will be disabled because a patient cannot fall under both the numerator and the numerator exclusion. If the user decides to instead assign the patient to the numerator exclusion, they will need to first deselect the numerator population.

Note: Future tasking will actually use the desired populations state - this PR sets up the selection and storage in anticipation for the future tasking.

## Code Changes
* New component `utils/PopulationMultiSelect` - renders a Mantine Multiselect component. Includes functions for grabbing the measure populations off the measure bundle, keeping track of the selected populations and selecting their superset populations, and disabling populations that cannot be selected alongside already-selected populations
* Add `desiredPopulations` to the `TestCaseInfo` interface so that the desired populations for the patient to fall under can be tracked for each patient
* Add `PopulationMultiSelect` component to the `PatientInfoCard`
* Unit tests for `PatientInfoCard` and `PopulationMultiSelect`

# Testing Guidance
Run unit tests. Then, create a new test patient and test the following:
* Select the patient and select the initial population. Then, deselect the patient and select it again. Check that the initial population selection appears, showing that the desired populations state gets saved.
* Select the patient and select the denominator - check that the initial population also gets selected. This should also be the case for any other population (that when you select it, the initial population also gets selected)
    * If the denominator exclusion is available on the measure, it should be disabled.
* Select the patient and select the numerator - check that the initial population and denominator also get selected.
    * If the numerator exclusion, denominator exclusion, and/or denominator exception are available on the measure, they should be disabled.
* Select the patient and select the numerator exclusion - check that the initial population and denominator also get selected.
    * The numerator should be disabled.
* Select the patient and select the denominator exclusion - check that the initial population also gets selected
    * Everything else should be disabled.
* Select the patient and select the denominator exception - check that the initial population and denominator also get selected
    * The denominator exclusion, numerator exclusion, and numerator should be disabled. (I used the DRCommunication bundle to get access to the denominator exception for testing)

Some things to get feedback on:
* Does it make sense to disable the populations that cannot be selected with the already-selected populations? Would it be more appropriate to use the error highlighting on the multi select component instead, or maybe show a Mantine notification? Or should we get rid of the disabling altogether if we don’t want to add this checking?
* Currently, measure-population, measure-population-exclusion, and measure-observation are not included in the MultiSelect component. Should we add any handling at this time for them?
* Check that the logic for selecting/disabling measure populations aligns with the eCQM population criteria: https://build.fhir.org/ig/HL7/cqf-measures/measure-conformance.html#population-criteria
