### PR TITLE
Measure upload UI

### DIFF
--- a/components/measure-upload/DateSelectors.tsx
+++ b/components/measure-upload/DateSelectors.tsx
@@ -1,5 +1,6 @@
 import { Grid } from '@mantine/core';
 import { DatePicker } from '@mantine/dates';
+import { IconCalendar } from '@tabler/icons';
 import { useRecoilState } from 'recoil';
 import { measurementPeriodState } from '../../state/atoms/measurementPeriod';
 
@@ -7,20 +8,22 @@ export default function DateSelectors() {
   const [period, setPeriod] = useRecoilState(measurementPeriodState);
   return (
     <Grid>
-      <Grid.Col span={6}>
+      <Grid.Col span={5}>
         <DatePicker
           placeholder="Select start date"
           label="Measurement Period Start"
           value={period.start}
           onChange={start => setPeriod({ ...period, start })}
+          icon={<IconCalendar size={16} />}
         />
       </Grid.Col>
-      <Grid.Col span={6}>
+      <Grid.Col span={5}>
         <DatePicker
           placeholder="Select end date"
           label="Measurement Period End"
           value={period.end}
           onChange={end => setPeriod({ ...period, end })}
+          icon={<IconCalendar size={16} />}
         />
       </Grid.Col>
     </Grid>

--- a/components/measure-upload/DateSelectors.tsx
+++ b/components/measure-upload/DateSelectors.tsx
@@ -14,7 +14,7 @@ export default function DateSelectors() {
           label="Measurement Period Start"
           value={period.start}
           onChange={start => setPeriod({ ...period, start })}
-          icon={<IconCalendar size={16} />}
+          icon={<IconCalendar size={25} />}
         />
       </Grid.Col>
       <Grid.Col span={5}>
@@ -23,7 +23,7 @@ export default function DateSelectors() {
           label="Measurement Period End"
           value={period.end}
           onChange={end => setPeriod({ ...period, end })}
-          icon={<IconCalendar size={16} />}
+          icon={<IconCalendar size={25} />}
         />
       </Grid.Col>
     </Grid>

--- a/components/measure-upload/MeasureUpload.tsx
+++ b/components/measure-upload/MeasureUpload.tsx
@@ -1,12 +1,18 @@
 import { Dropzone } from '@mantine/dropzone';
 import { showNotification } from '@mantine/notifications';
-import { Grid, Center, Text, Stack } from '@mantine/core';
+import { Grid, Center, Text, Stack, createStyles } from '@mantine/core';
 import { IconFileImport, IconFileCheck, IconAlertCircle } from '@tabler/icons';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { measureBundleState } from '../../state/atoms/measureBundle';
 import MissingValueSetModal from '../modals/MissingValueSetModal';
 import { measurementPeriodState } from '../../state/atoms/measurementPeriod';
 import { DateTime } from 'luxon';
+
+const useStyles = createStyles({
+  text: {
+    wordBreak: 'break-all'
+  }
+});
 
 export const DEFAULT_MEASUREMENT_PERIOD = {
   start: DateTime.fromISO('2022-01-01').toJSDate(),
@@ -82,12 +88,14 @@ export default function MeasureUpload() {
 
 function DropzoneChildren() {
   const measureBundle = useRecoilValue(measureBundleState);
+  const { classes } = useStyles();
+
   return (
     <Grid justify="center" align="center" style={{ minHeight: 200 }}>
       <Stack>
         <Center>{measureBundle.name ? <IconFileCheck size={80} /> : <IconFileImport size={80} />}</Center>
         <Center>
-          <Text size="xl" inline>
+          <Text size="xl" inline className={classes.text}>
             {measureBundle.name ? measureBundle.name : 'Drag a Measure Bundle JSON file here or click to select files'}
           </Text>
         </Center>

--- a/components/measure-upload/MeasureUpload.tsx
+++ b/components/measure-upload/MeasureUpload.tsx
@@ -1,6 +1,6 @@
 import { Dropzone } from '@mantine/dropzone';
 import { showNotification } from '@mantine/notifications';
-import { Grid, Center, Text, Group, Stack } from '@mantine/core';
+import { Grid, Center, Text, Stack } from '@mantine/core';
 import { IconFileImport, IconFileCheck, IconAlertCircle } from '@tabler/icons';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { measureBundleState } from '../../state/atoms/measureBundle';
@@ -72,7 +72,7 @@ export default function MeasureUpload() {
         }
         accept={['application/json']}
         multiple={false}
-        style={{ height: 350 }}
+        style={{ minHeight: 200 }}
       >
         <DropzoneChildren />
       </Dropzone>
@@ -83,7 +83,7 @@ export default function MeasureUpload() {
 function DropzoneChildren() {
   const measureBundle = useRecoilValue(measureBundleState);
   return (
-    <Grid justify="center" align="center" style={{ height: 350 }}>
+    <Grid justify="center" align="center" style={{ minHeight: 200 }}>
       <Stack>
         <Center>{measureBundle.name ? <IconFileCheck size={80} /> : <IconFileImport size={80} />}</Center>
         <Center>

--- a/components/measure-upload/MeasureUpload.tsx
+++ b/components/measure-upload/MeasureUpload.tsx
@@ -1,6 +1,6 @@
 import { Dropzone } from '@mantine/dropzone';
 import { showNotification } from '@mantine/notifications';
-import { Grid, Center, Text } from '@mantine/core';
+import { Grid, Center, Text, Group, Stack } from '@mantine/core';
 import { IconFileImport, IconFileCheck, IconAlertCircle } from '@tabler/icons';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { measureBundleState } from '../../state/atoms/measureBundle';
@@ -72,6 +72,7 @@ export default function MeasureUpload() {
         }
         accept={['application/json']}
         multiple={false}
+        style={{ height: 350 }}
       >
         <DropzoneChildren />
       </Dropzone>
@@ -82,17 +83,15 @@ export default function MeasureUpload() {
 function DropzoneChildren() {
   const measureBundle = useRecoilValue(measureBundleState);
   return (
-    <Grid justify="center">
-      <Grid.Col span={12}>
+    <Grid justify="center" align="center" style={{ height: 350 }}>
+      <Stack>
         <Center>{measureBundle.name ? <IconFileCheck size={80} /> : <IconFileImport size={80} />}</Center>
-      </Grid.Col>
-      <Grid.Col>
         <Center>
           <Text size="xl" inline>
             {measureBundle.name ? measureBundle.name : 'Drag a Measure Bundle JSON file here or click to select files'}
           </Text>
         </Center>
-      </Grid.Col>
+      </Stack>
     </Grid>
   );
 }

--- a/components/utils/DateSelectorsHeader.tsx
+++ b/components/utils/DateSelectorsHeader.tsx
@@ -1,7 +1,7 @@
 import { Text, Group } from '@mantine/core';
 import React from 'react';
 
-export default function DateSelectorHeader() {
+export default function DateSelectorsHeader() {
   return (
     <Group>
       <div style={{ paddingRight: 5 }}>

--- a/components/utils/DateSelectorsHeader.tsx
+++ b/components/utils/DateSelectorsHeader.tsx
@@ -5,7 +5,7 @@ export default function DateSelectorHeader() {
   return (
     <Group>
       <div style={{ paddingRight: 5 }}>
-        <Text size="xl">Step 2: Set your Measurement period date range</Text>
+        <Text size="xl">Step 2: Set your Measurement Period Date Range</Text>
       </div>
     </Group>
   );

--- a/components/utils/DateSelectorsHeader.tsx
+++ b/components/utils/DateSelectorsHeader.tsx
@@ -1,0 +1,12 @@
+import { Text, Group } from '@mantine/core';
+import React from 'react';
+
+export default function DateSelectorHeader() {
+  return (
+    <Group>
+      <div style={{ paddingRight: 5 }}>
+        <Text size="xl">Step 2: Set your Measurement period date range</Text>
+      </div>
+    </Group>
+  );
+}

--- a/components/utils/DateSelectorsHeader.tsx
+++ b/components/utils/DateSelectorsHeader.tsx
@@ -5,7 +5,9 @@ export default function DateSelectorsHeader() {
   return (
     <Group>
       <div style={{ paddingRight: 5 }}>
-        <Text size="xl">Step 2: Set your Measurement Period Date Range</Text>
+        <Text size="xl" weight={700}>
+          Step 2: Set your Measurement Period Date Range
+        </Text>
       </div>
     </Group>
   );

--- a/components/utils/MeasureUploadHeader.tsx
+++ b/components/utils/MeasureUploadHeader.tsx
@@ -8,7 +8,9 @@ export default function MeasureUploadHeader() {
   return (
     <Group>
       <div style={{ paddingRight: 5 }}>
-        <Text size="xl">Step 1: Upload a Measure Bundle</Text>
+        <Text size="xl" weight={700}>
+          Step 1: Upload a Measure Bundle
+        </Text>
       </div>
       <div>
         <Popover opened={opened} onClose={() => setOpened(false)}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -6811,7 +6811,7 @@
         "object-keys": {
           "version": "0.4.0",
           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
+          "integrity": "sha512-ncrLw+X55z7bkl5PnUvHwFK9FcGuFYo9gtjws2XtSzL+aZ8tm830P60WJ0dSmFVaSalWieW5MD7kEdnXda9yJw=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -6811,7 +6811,7 @@
         "object-keys": {
           "version": "0.4.0",
           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-          "integrity": "sha512-ncrLw+X55z7bkl5PnUvHwFK9FcGuFYo9gtjws2XtSzL+aZ8tm830P60WJ0dSmFVaSalWieW5MD7kEdnXda9yJw=="
+          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
         }
       }
     },

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -20,14 +20,14 @@ const Home: NextPage = () => {
       </Head>
       <Grid justify="center">
         <Grid.Col span={5}>
-          <Stack justify="space-between" spacing="xl">
+          <Stack justify="space-evenly" spacing="xl">
             <MeasureUploadHeader />
             <MeasureUpload />
             <Space />
             <DateSelectorsHeader />
             <DateSelectors />
-            <Link href={'/generate-test-cases'}>
-              <Group position="right">
+            <Group position="right">
+              <Link href={'/generate-test-cases'}>
                 <Button
                   sx={() => ({
                     marginTop: 10
@@ -36,8 +36,8 @@ const Home: NextPage = () => {
                 >
                   Next
                 </Button>
-              </Group>
-            </Link>
+              </Link>
+            </Group>
           </Stack>
         </Grid.Col>
       </Grid>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -8,7 +8,7 @@ import { measureBundleState } from '../state/atoms/measureBundle';
 import { measurementPeriodState } from '../state/atoms/measurementPeriod';
 import { useRecoilValue } from 'recoil';
 import MeasureUploadHeader from '../components/utils/MeasureUploadHeader';
-import DateSelectorHeader from '../components/utils/DateSelectorsHeader';
+import DateSelectorsHeader from '../components/utils/DateSelectorsHeader';
 
 const Home: NextPage = () => {
   const measureBundle = useRecoilValue(measureBundleState);
@@ -24,7 +24,7 @@ const Home: NextPage = () => {
             <MeasureUploadHeader />
             <MeasureUpload />
             <Space />
-            <DateSelectorHeader />
+            <DateSelectorsHeader />
             <DateSelectors />
             <Link href={'/generate-test-cases'}>
               <Group position="right">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,7 @@
 import type { NextPage } from 'next';
 import Link from 'next/link';
 import Head from 'next/head';
-import { Button, Divider, Grid, Group, SimpleGrid } from '@mantine/core';
+import { Button, Grid, Group, Space, Stack } from '@mantine/core';
 import MeasureUpload from '../components/measure-upload/MeasureUpload';
 import DateSelectors from '../components/measure-upload/DateSelectors';
 import { measureBundleState } from '../state/atoms/measureBundle';
@@ -9,7 +9,6 @@ import { measurementPeriodState } from '../state/atoms/measurementPeriod';
 import { useRecoilValue } from 'recoil';
 import MeasureUploadHeader from '../components/utils/MeasureUploadHeader';
 import DateSelectorHeader from '../components/utils/DateSelectorsHeader';
-import { Divide } from 'tabler-icons-react';
 
 const Home: NextPage = () => {
   const measureBundle = useRecoilValue(measureBundleState);
@@ -19,41 +18,27 @@ const Home: NextPage = () => {
       <Head>
         <title>FQM Testify: an eCQM Analysis Tool</title>
       </Head>
-      {/* <Grid justify="center" align="stretch">
-        <SimpleGrid cols={1}>
-          <MeasureUploadHeader />
-          <MeasureUpload />
-          <Divider />
-          <DateSelectorHeader />
-          <DateSelectors />
-        </SimpleGrid>
-      </Grid> */}
       <Grid justify="center">
-        <Grid.Col span={7}>
-          <MeasureUploadHeader />
-        </Grid.Col>
-        <Grid.Col span={7}>
-          <MeasureUpload />
-        </Grid.Col>
-        <Grid.Col span={7}>
-          <DateSelectorHeader />
-        </Grid.Col>
-        <Grid.Col span={7}>
-          <DateSelectors />
-        </Grid.Col>
-        <Grid.Col span={7}>
-          <Link href={'/generate-test-cases'}>
-            <Group position="right">
-              <Button
-                sx={() => ({
-                  marginTop: 10
-                })}
-                disabled={!(measureBundle.name && measurementPeriod.start && measurementPeriod.end)}
-              >
-                Next
-              </Button>
-            </Group>
-          </Link>
+        <Grid.Col span={5}>
+          <Stack justify="space-between" spacing="xl">
+            <MeasureUploadHeader />
+            <MeasureUpload />
+            <Space />
+            <DateSelectorHeader />
+            <DateSelectors />
+            <Link href={'/generate-test-cases'}>
+              <Group position="right">
+                <Button
+                  sx={() => ({
+                    marginTop: 10
+                  })}
+                  disabled={!(measureBundle.name && measurementPeriod.start && measurementPeriod.end)}
+                >
+                  Next
+                </Button>
+              </Group>
+            </Link>
+          </Stack>
         </Grid.Col>
       </Grid>
     </>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,13 +1,15 @@
 import type { NextPage } from 'next';
 import Link from 'next/link';
 import Head from 'next/head';
-import { Button, Grid } from '@mantine/core';
+import { Button, Divider, Grid, Group, SimpleGrid } from '@mantine/core';
 import MeasureUpload from '../components/measure-upload/MeasureUpload';
 import DateSelectors from '../components/measure-upload/DateSelectors';
 import { measureBundleState } from '../state/atoms/measureBundle';
 import { measurementPeriodState } from '../state/atoms/measurementPeriod';
 import { useRecoilValue } from 'recoil';
 import MeasureUploadHeader from '../components/utils/MeasureUploadHeader';
+import DateSelectorHeader from '../components/utils/DateSelectorsHeader';
+import { Divide } from 'tabler-icons-react';
 
 const Home: NextPage = () => {
   const measureBundle = useRecoilValue(measureBundleState);
@@ -17,27 +19,43 @@ const Home: NextPage = () => {
       <Head>
         <title>FQM Testify: an eCQM Analysis Tool</title>
       </Head>
-      <Grid>
-        <Grid.Col span={12}>
+      {/* <Grid justify="center" align="stretch">
+        <SimpleGrid cols={1}>
+          <MeasureUploadHeader />
+          <MeasureUpload />
+          <Divider />
+          <DateSelectorHeader />
+          <DateSelectors />
+        </SimpleGrid>
+      </Grid> */}
+      <Grid justify="center">
+        <Grid.Col span={7}>
           <MeasureUploadHeader />
         </Grid.Col>
-        <Grid.Col span={12}>
+        <Grid.Col span={7}>
           <MeasureUpload />
         </Grid.Col>
-        <Grid.Col span={12}>
+        <Grid.Col span={7}>
+          <DateSelectorHeader />
+        </Grid.Col>
+        <Grid.Col span={7}>
           <DateSelectors />
         </Grid.Col>
+        <Grid.Col span={7}>
+          <Link href={'/generate-test-cases'}>
+            <Group position="right">
+              <Button
+                sx={() => ({
+                  marginTop: 10
+                })}
+                disabled={!(measureBundle.name && measurementPeriod.start && measurementPeriod.end)}
+              >
+                Next
+              </Button>
+            </Group>
+          </Link>
+        </Grid.Col>
       </Grid>
-      <Link href={'/generate-test-cases'}>
-        <Button
-          sx={() => ({
-            marginTop: 10
-          })}
-          disabled={!(measureBundle.name && measurementPeriod.start && measurementPeriod.end)}
-        >
-          Next
-        </Button>
-      </Link>
     </>
   );
 };


### PR DESCRIPTION
# Summary
This PR updates the UI of the measure upload page to be more inline with that we were given by the UI/UX team in the mockups. There are now "Step 1" and "Step 2" headers for the measure upload and the date pickers. The measure upload and date pickers also take up less room as shown in the mockups. Calendar icons are added to the date pickers.

## New Behavior
There is no new behavior.

## Code Changes
- `pages/index.tsx` - now renders the `DateSelectorsHeader` in addition to the other components on the page. The components are now in a stack so that they can be in a `Grid.Col` has has a span of 5.
- `components/utils/DateSelectorsHeader.tsx` - creates a new `DateSelectorsHeader` component.
- `components/measure-upload/MeasureUpload.tsx` - Gives the drop zone a minimum height so that it is a bit larger on the page.
- `components/measure-upload/DateSelectors.tsx` - Adds a calendar icon to the date pickers and makes the date pickers smaller.

# Testing Guidance
- Run `npm run check` to ensure that all tests pass and there are no warnings.
- Run `npm run dev` to ensure that the app functions the same way (upload a measure, change the dates, etc.)
- Look at the mockup page (attached below) to see that the current design resembles that.
- Give me any feedback about the design!

NOTE: In the mockups, the calendar icon is on the right of the date pickers. It seems as though Mantine only gives  you the option to put it on the left. If you feel strongly about it being on the right, let me know and I will do my best to work around that!

Mockup: 
![image](https://user-images.githubusercontent.com/30158156/191313484-d1da8e20-ca01-4409-9fc6-06fea725e4fc.png)
