### PR TITLE
UI bug

### DIFF
--- a/__tests__/components/utils/PatientInfoCard.test.tsx
+++ b/__tests__/components/utils/PatientInfoCard.test.tsx
@@ -169,17 +169,7 @@ describe('PatientInfoCard', () => {
 
   it('should render a patient actions menu when the screen is small', () => {
     render(
-      mantineRecoilWrap(
-        <PatientInfoCard
-          patient={EXAMPLE_PATIENT}
-          onEditClick={jest.fn()}
-          onDeleteClick={jest.fn()}
-          onExportClick={jest.fn()}
-          onCopyClick={jest.fn()}
-          selected={true}
-          smallScreen={true}
-        />
-      )
+      mantineRecoilWrap(<PatientInfoCard patient={EXAMPLE_PATIENT} {...MOCK_CALLBACK_PROPS} smallScreen={true} />)
     );
     expect(screen.getByLabelText(/menu button/i)).toBeInTheDocument();
   });

--- a/__tests__/components/utils/PatientInfoCard.test.tsx
+++ b/__tests__/components/utils/PatientInfoCard.test.tsx
@@ -55,7 +55,8 @@ const MOCK_CALLBACK_PROPS: Omit<PatientInfoCardProps, 'patient'> = {
   onDeleteClick: jest.fn(),
   onExportClick: jest.fn(),
   onCopyClick: jest.fn(),
-  selected: true
+  selected: true,
+  smallScreen: false
 };
 
 describe('PatientInfoCard', () => {
@@ -164,5 +165,22 @@ describe('PatientInfoCard', () => {
 
     const populationSelector = screen.getByPlaceholderText(/select populations/i) as HTMLInputElement;
     expect(populationSelector).toBeInTheDocument();
+  });
+
+  it('should render a patient actions menu when the screen is small', () => {
+    render(
+      mantineRecoilWrap(
+        <PatientInfoCard
+          patient={EXAMPLE_PATIENT}
+          onEditClick={jest.fn()}
+          onDeleteClick={jest.fn()}
+          onExportClick={jest.fn()}
+          onCopyClick={jest.fn()}
+          selected={true}
+          smallScreen={true}
+        />
+      )
+    );
+    expect(screen.getByLabelText(/menu button/i)).toBeInTheDocument();
   });
 });

--- a/components/patient-creation/PatientCreationPanel.tsx
+++ b/components/patient-creation/PatientCreationPanel.tsx
@@ -27,6 +27,7 @@ import PopulationCalculation from '../calculation/PopulationCalculation';
 import { calculateMeasureReport } from '../../util/MeasureCalculation';
 import { calculationLoading } from '../../state/atoms/calculationLoading';
 import { measureReportLookupState } from '../../state/atoms/measureReportLookup';
+import { useMediaQuery } from '@mantine/hooks';
 
 function PatientCreationPanel() {
   const [isPatientModalOpen, setIsPatientModalOpen] = useState(false);
@@ -41,6 +42,7 @@ function PatientCreationPanel() {
   const measurementPeriod = useRecoilValue(measurementPeriodState);
   const setIsCalculationLoading = useSetRecoilState(calculationLoading);
   const [measureReportLookup, setMeasureReportLookup] = useRecoilState(measureReportLookupState);
+  const isSmallScreen = useMediaQuery('(max-width: 1600px)');
 
   const openPatientModal = (patientId?: string, copy = false) => {
     if (patientId && Object.keys(currentPatients).includes(patientId)) {
@@ -411,6 +413,7 @@ function PatientCreationPanel() {
                   onEditClick={() => openPatientModal(id)}
                   onDeleteClick={() => openConfirmationModal()}
                   selected={selectedPatient === id}
+                  smallScreen={isSmallScreen}
                 />
               </div>
             ))}

--- a/components/utils/PatientInfoCard.tsx
+++ b/components/utils/PatientInfoCard.tsx
@@ -56,7 +56,51 @@ export default function PatientInfoCard({
         </Grid.Col>
         <Grid.Col span={6}>
           <Group position="right">
-            {!smallScreen ? (
+            {smallScreen ? (
+              <Menu shadow="md" width={200}>
+                <Menu.Target>
+                  <Button variant="subtle" aria-label={'Menu Button'}>
+                    <Dots />
+                  </Button>
+                </Menu.Target>
+                <Menu.Dropdown>
+                  <Menu.Label>Patient Actions</Menu.Label>
+                  <Menu.Item
+                    icon={<Download size={20} />}
+                    onClick={() => {
+                      onExportClick();
+                    }}
+                  >
+                    Download Patient
+                  </Menu.Item>
+                  <Menu.Item
+                    icon={<Edit size={20} />}
+                    onClick={() => {
+                      onEditClick();
+                    }}
+                  >
+                    Edit Patient
+                  </Menu.Item>
+                  <Menu.Item
+                    icon={<Copy size={20} />}
+                    onClick={() => {
+                      onCopyClick();
+                    }}
+                  >
+                    Copy Patient
+                  </Menu.Item>
+                  <Menu.Item
+                    icon={<Trash size={20} />}
+                    color="red"
+                    onClick={() => {
+                      onDeleteClick();
+                    }}
+                  >
+                    Delete Patient
+                  </Menu.Item>
+                </Menu.Dropdown>
+              </Menu>
+            ) : (
               <Center>
                 <Tooltip label="Export Patient" openDelay={1000}>
                   <Button
@@ -109,49 +153,6 @@ export default function PatientInfoCard({
                   </Button>
                 </Tooltip>
               </Center>
-            ) : (
-              <Menu shadow="md" width={200}>
-                <Menu.Target>
-                  <Button variant="subtle" aria-label={'Menu Button'}>
-                    <Dots />
-                  </Button>
-                </Menu.Target>
-                <Menu.Dropdown>
-                  <Menu.Label>Patient Actions</Menu.Label>
-                  <Menu.Item
-                    icon={<Download size={14} />}
-                    onClick={() => {
-                      onExportClick();
-                    }}
-                  >
-                    Download Patient
-                  </Menu.Item>
-                  <Menu.Item
-                    icon={<Edit size={14} />}
-                    onClick={() => {
-                      onEditClick();
-                    }}
-                  >
-                    Edit Patient
-                  </Menu.Item>
-                  <Menu.Item
-                    icon={<Copy size={14} />}
-                    onClick={() => {
-                      onCopyClick();
-                    }}
-                  >
-                    Copy Patient
-                  </Menu.Item>
-                  <Menu.Item
-                    icon={<Trash size={14} />}
-                    onClick={() => {
-                      onDeleteClick();
-                    }}
-                  >
-                    Delete Patient
-                  </Menu.Item>
-                </Menu.Dropdown>
-              </Menu>
             )}
           </Group>
         </Grid.Col>

--- a/components/utils/PatientInfoCard.tsx
+++ b/components/utils/PatientInfoCard.tsx
@@ -1,6 +1,7 @@
-import { Button, Center, Divider, Grid, Paper, Sx, Text, Tooltip } from '@mantine/core';
+import { Button, Center, Divider, Grid, Group, Menu, Paper, Sx, Text, Tooltip } from '@mantine/core';
+import { useMediaQuery } from '@mantine/hooks';
 import React from 'react';
-import { Copy, Download, Edit, Trash } from 'tabler-icons-react';
+import { Copy, Dots, Download, Edit, Trash } from 'tabler-icons-react';
 import { getPatientDOBString, getPatientNameString } from '../../util/fhir';
 import PopulationMultiSelect from './PopulationMultiSelect';
 
@@ -21,6 +22,7 @@ export default function PatientInfoCard({
   onDeleteClick,
   selected
 }: PatientInfoCardProps) {
+  const matches = useMediaQuery('(min-width: 1600px)');
   return (
     <Paper
       shadow="sm"
@@ -43,8 +45,8 @@ export default function PatientInfoCard({
         return style;
       }}
     >
-      <Grid justify="center" align="center">
-        <Grid.Col span={5}>
+      <Grid align="center">
+        <Grid.Col span={6}>
           <div>
             <Text size="sm">{getPatientNameString(patient)}</Text>
             <Text size="xs" color="dimmed">
@@ -52,59 +54,106 @@ export default function PatientInfoCard({
             </Text>
           </div>
         </Grid.Col>
-        <Grid.Col span={5} offset={2} style={{ paddingRight: 25 }}>
-          <Center>
-            <Tooltip label="Export Patient" openDelay={1000}>
-              <Button
-                size="xs"
-                aria-label={'Export Patient'}
-                onClick={() => {
-                  onExportClick();
-                }}
-                variant="subtle"
-              >
-                <Download />
-              </Button>
-            </Tooltip>
-            <Tooltip label="Edit Patient" openDelay={1000}>
-              <Button
-                aria-label={'Edit Patient'}
-                onClick={() => {
-                  onEditClick();
-                }}
-                variant="subtle"
-                size="xs"
-              >
-                <Edit />
-              </Button>
-            </Tooltip>
-            <Tooltip label="Copy Patient" openDelay={1000}>
-              <Button
-                size="xs"
-                aria-label={'Copy Patient'}
-                onClick={() => {
-                  onCopyClick();
-                }}
-                variant="subtle"
-              >
-                <Copy />
-              </Button>
-            </Tooltip>
-            <Divider sx={{ height: '48px' }} size="xs" orientation="vertical" />
-            <Tooltip label="Delete Patient" openDelay={1000}>
-              <Button
-                size="xs"
-                aria-label={'Delete Patient'}
-                onClick={() => {
-                  onDeleteClick();
-                }}
-                color="red"
-                variant="subtle"
-              >
-                <Trash />
-              </Button>
-            </Tooltip>
-          </Center>
+        <Grid.Col span={6}>
+          <Group position="right">
+            {matches ? (
+              <Center>
+                <Tooltip label="Export Patient" openDelay={1000}>
+                  <Button
+                    size="xs"
+                    aria-label={'Export Patient'}
+                    onClick={() => {
+                      onExportClick();
+                    }}
+                    variant="subtle"
+                  >
+                    <Download />
+                  </Button>
+                </Tooltip>
+                <Tooltip label="Edit Patient" openDelay={1000}>
+                  <Button
+                    aria-label={'Edit Patient'}
+                    onClick={() => {
+                      onEditClick();
+                    }}
+                    variant="subtle"
+                    size="xs"
+                  >
+                    <Edit />
+                  </Button>
+                </Tooltip>
+                <Tooltip label="Copy Patient" openDelay={1000}>
+                  <Button
+                    size="xs"
+                    aria-label={'Copy Patient'}
+                    onClick={() => {
+                      onCopyClick();
+                    }}
+                    variant="subtle"
+                  >
+                    <Copy />
+                  </Button>
+                </Tooltip>
+                <Divider sx={{ height: '48px' }} size="xs" orientation="vertical" />
+                <Tooltip label="Delete Patient" openDelay={1000}>
+                  <Button
+                    size="xs"
+                    aria-label={'Delete Patient'}
+                    onClick={() => {
+                      onDeleteClick();
+                    }}
+                    color="red"
+                    variant="subtle"
+                  >
+                    <Trash />
+                  </Button>
+                </Tooltip>
+              </Center>
+            ) : (
+              <Menu shadow="md" width={200}>
+                <Menu.Target>
+                  <Button variant="subtle">
+                    <Dots />
+                  </Button>
+                </Menu.Target>
+                <Menu.Dropdown>
+                  <Menu.Label>Patient Actions</Menu.Label>
+                  <Menu.Item
+                    icon={<Download size={14} />}
+                    onClick={() => {
+                      onExportClick();
+                    }}
+                  >
+                    Download Patient
+                  </Menu.Item>
+                  <Menu.Item
+                    icon={<Edit size={14} />}
+                    onClick={() => {
+                      onEditClick();
+                    }}
+                  >
+                    Edit Patient
+                  </Menu.Item>
+                  <Menu.Item
+                    icon={<Copy size={14} />}
+                    onClick={() => {
+                      onCopyClick();
+                    }}
+                  >
+                    Copy Patient
+                  </Menu.Item>
+                  <Menu.Item
+                    icon={<Trash size={14} />}
+                    onClick={() => {
+                      onDeleteClick();
+                    }}
+                  >
+                    Delete Patient
+                  </Menu.Item>
+                </Menu.Dropdown>
+              </Menu>
+            )}
+          </Group>
         </Grid.Col>
       </Grid>
       {selected && <PopulationMultiSelect />}

--- a/components/utils/PatientInfoCard.tsx
+++ b/components/utils/PatientInfoCard.tsx
@@ -1,5 +1,4 @@
 import { Button, Center, Divider, Grid, Group, Menu, Paper, Sx, Text, Tooltip } from '@mantine/core';
-import { useMediaQuery } from '@mantine/hooks';
 import React from 'react';
 import { Copy, Dots, Download, Edit, Trash } from 'tabler-icons-react';
 import { getPatientDOBString, getPatientNameString } from '../../util/fhir';
@@ -12,6 +11,7 @@ export interface PatientInfoCardProps {
   onEditClick: (...args: unknown[]) => void;
   onDeleteClick: (...args: unknown[]) => void;
   selected?: boolean;
+  smallScreen?: boolean;
 }
 
 export default function PatientInfoCard({
@@ -20,9 +20,9 @@ export default function PatientInfoCard({
   onExportClick,
   onEditClick,
   onDeleteClick,
-  selected
+  selected,
+  smallScreen
 }: PatientInfoCardProps) {
-  const matches = useMediaQuery('(min-width: 1600px)');
   return (
     <Paper
       shadow="sm"
@@ -56,7 +56,7 @@ export default function PatientInfoCard({
         </Grid.Col>
         <Grid.Col span={6}>
           <Group position="right">
-            {matches ? (
+            {!smallScreen ? (
               <Center>
                 <Tooltip label="Export Patient" openDelay={1000}>
                   <Button
@@ -112,7 +112,7 @@ export default function PatientInfoCard({
             ) : (
               <Menu shadow="md" width={200}>
                 <Menu.Target>
-                  <Button variant="subtle">
+                  <Button variant="subtle" aria-label={'Menu Button'}>
                     <Dots />
                   </Button>
                 </Menu.Target>


### PR DESCRIPTION
# Summary
This was not a task but just an end of sprint activity. The download, edit, copy, and delete buttons of the `PatientInfoCard` were a little off and it got cut off if the user resized the window. This is how it looked: 

<img width="476" alt="Screen Shot 2022-09-26 at 12 22 41 PM" src="https://user-images.githubusercontent.com/30158156/192342708-92dc4318-e9b1-4b30-a118-17494958aebe.png">

<img width="269" alt="Screen Shot 2022-09-26 at 12 22 57 PM" src="https://user-images.githubusercontent.com/30158156/192342718-685a0fe3-1572-49fd-8495-ef5b5860e4bd.png">

 I fixed the layout so that doesn't happen any more.

## New Behavior
- When a user shrinks the screen to a point where the patient name and buttons would overlap, now a menu button appears in place of the four buttons. When the user clicks on the menu button, a dropdown menu appears with those 4 options that are their own buttons when the screen is large enough. All other behavior remains the same.

## Code Changes
- `PatientCreationPanel.tsx` - set `isSmallScreen` to true if the max-width of the window is 1600px.
- `PatientInfoCard.tsx` - if the screen is small, a menu button is rendered in place of the four buttons. 
- `PatientInfoCard.test.tsx` - updated tests to reflect new changes.

# Testing Guidance
1. Run `npm run check` and make sure all tests pass and there are no lint or prettier errors.
2. Run `npm run dev`, upload a measure bundle, and create a patient.
3. In a normal sized window, you should see the four original buttons and there should be no overlap like there was previously.
4. Try resizing the window. If you shrink the window, you should see that the four buttons become one menu button. Try out all of the options in the menu to make sure that they work.
5. Let me know if you find anything or have any style changes/ideas!