### PR TITLE
Made header flush with the test case editor

### DIFF
--- a/components/TestCaseEditor.tsx
+++ b/components/TestCaseEditor.tsx
@@ -64,7 +64,7 @@ export default function TestCaseEditor() {
 
   return (
     <>
-      <Grid style={{ height: '85vh' }}>
+      <Grid style={{ height: 'calc(100vh - 120px)' }}>
         <Grid.Col span={3} className={classes.panel}>
           <PatientCreationPanel />
         </Grid.Col>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -15,7 +15,7 @@ export default function App(props: AppProps) {
   return (
     <RecoilRoot>
       <Head>
-        <title>FQM Testify: an eCQM Analysis Tool</title>
+        <title>FQM Testify: a FHIR-based eCQM Analysis Tool</title>
         <meta name="viewport" content="minimum-scale=1, initial-scale=1, width=device-width" />
         <link rel="icon" href="/favicon.ico" />
       </Head>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -15,14 +15,17 @@ export default function App(props: AppProps) {
   return (
     <RecoilRoot>
       <Head>
-        <title>FQM Testify: an ECQM Analysis Tool</title>
+        <title>FQM Testify: an eCQM Analysis Tool</title>
         <meta name="viewport" content="minimum-scale=1, initial-scale=1, width=device-width" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <ColorSchemeProvider colorScheme={colorScheme} toggleColorScheme={toggleColorScheme}>
         <MantineProvider withGlobalStyles withNormalizeCSS theme={{ colorScheme }}>
           <NotificationsProvider position="top-center">
-            <AppShell padding="md" header={<Header height={120}>{<AppHeader></AppHeader>}</Header>}>
+            <AppShell
+              style={{ marginTop: '-8px', marginBottom: '-8px', marginLeft: '-8px', marginRight: '-8px' }}
+              header={<Header height={120}>{<AppHeader></AppHeader>}</Header>}
+            >
               <Component {...pageProps} />
             </AppShell>
           </NotificationsProvider>

--- a/pages/generate-test-cases.tsx
+++ b/pages/generate-test-cases.tsx
@@ -58,7 +58,7 @@ const TestCaseEditorPage: NextPage = () => {
 
   return (
     <>
-      <div style={{ paddingTop: '24px' }}>
+      <div>
         {start && end && measureBundle.content ? (
           <TestCaseEditor />
         ) : (

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,5 @@
 import type { NextPage } from 'next';
 import Link from 'next/link';
-import Head from 'next/head';
 import { useCallback, useEffect, useState } from 'react';
 import { Button, Grid, Group, Space, Stack } from '@mantine/core';
 import { useRecoilValue } from 'recoil';
@@ -37,9 +36,6 @@ const Home: NextPage = () => {
 
   return (
     <>
-      <Head>
-        <title>FQM Testify: an eCQM Analysis Tool</title>
-      </Head>
       <Grid justify="center">
         <Grid.Col span={5}>
           <Stack justify="space-evenly" spacing="xl">


### PR DESCRIPTION
# Summary
Makes the test case editor panels flush against the header.

## New Behavior
No new behavior.

## Code Changes
- `components/TestCaseEditor.tsx` - Changes the height of the grid from `85vh` to be the height of the window subtracted by the height of the header so that it fits the full screen.
- `pages/_app.tsx` - Changes the margins of the `AppShell` because Mantine automatically gives them 16px of padding.
- `pages/generate-test-cases.tsx` - Removed the top padding.
- `pages/index.tsx` - Delete a `<Head>` that we no longer need because it is in `_app.tsx`.

# Testing Guidance
- Run `npm run check` to ensure that there are no lint errors or warnings and that all tests still pass.
- `npm run dev` and make sure that the UI of the app is consistent in different window sizes and looks good overall. 
- Let me know if you have any comments or suggestions!

Before:
<img width="1050" alt="image" src="https://user-images.githubusercontent.com/30158156/203418010-f1926012-5f21-49b9-94a6-0331660d7f03.png">

After: 
<img width="833" alt="image" src="https://user-images.githubusercontent.com/30158156/203417897-17eec7f2-a777-4fcc-81ea-2c43f023cf61.png">
