### PR TITLE
Mrs input

### DIFF
--- a/__tests__/components/calculation/PopulationCalculation.test.tsx
+++ b/__tests__/components/calculation/PopulationCalculation.test.tsx
@@ -5,7 +5,7 @@ import { patientTestCaseState } from '../../../state/atoms/patientTestCase';
 import { getMockRecoilState, mantineRecoilWrap } from '../../helpers/testHelpers';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { Calculator, MeasureReportBuilder } from 'fqm-execution';
-import MeasureUpload from '../../../components/measure-upload/MeasureUpload';
+import MeasureUpload from '../../../components/measure-upload/MeasureFileUpload';
 
 const MOCK_MEASURE_REPORT: fhir4.MeasureReport = {
   resourceType: 'MeasureReport',

--- a/__tests__/components/measure-upload/MeasureFileUpload.test.tsx
+++ b/__tests__/components/measure-upload/MeasureFileUpload.test.tsx
@@ -12,7 +12,7 @@ const MOCK_BUNDLE: fhir4.Bundle = {
 
 describe('MeasureUpload', () => {
   it('renders a dropzone with generic label when no measure uploaded', () => {
-    render(mantineRecoilWrap(<MeasureUpload />));
+    render(mantineRecoilWrap(<MeasureUpload logError={jest.fn()} />));
 
     const title = screen.getByText('Drag a Measure Bundle JSON file here or click to select files');
     expect(title).toBeInTheDocument();
@@ -28,8 +28,12 @@ describe('MeasureUpload', () => {
     });
 
     const MockMB = getMockRecoilState(measureBundleState, {
-      name: 'testName',
-      content: MOCK_BUNDLE
+      fileName: 'testName',
+      content: MOCK_BUNDLE,
+      isFile: true,
+      measureRepositoryUrl: '',
+      selectedMeasureId: null,
+      displayMap: {}
     });
 
     await act(async () => {
@@ -37,7 +41,7 @@ describe('MeasureUpload', () => {
         mantineRecoilWrap(
           <>
             <MockMB />
-            <MeasureUpload />
+            <MeasureUpload logError={jest.fn()} />
           </>
         )
       );

--- a/__tests__/components/measure-upload/MeasureUpload.test.tsx
+++ b/__tests__/components/measure-upload/MeasureUpload.test.tsx
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom';
 import { Calculator } from 'fqm-execution';
 import { mantineRecoilWrap, getMockRecoilState } from '../../helpers/testHelpers';
 import { measureBundleState } from '../../../state/atoms/measureBundle';
-import MeasureUpload from '../../../components/measure-upload/MeasureUpload';
+import MeasureUpload from '../../../components/measure-upload/MeasureFileUpload';
 
 const MOCK_BUNDLE: fhir4.Bundle = {
   resourceType: 'Bundle',

--- a/__tests__/components/measure-upload/UploadErrorLog.test.tsx
+++ b/__tests__/components/measure-upload/UploadErrorLog.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
-import { MeasureUploadError } from '../../../components/measure-upload/MeasureUpload';
+import { MeasureUploadError } from '../../../components/measure-upload/MeasureFileUpload';
 import UploadErrorLog from '../../../components/measure-upload/UploadErrorLog';
 import { mantineRecoilWrap, mockResizeObserver } from '../../helpers/testHelpers';
 

--- a/__tests__/components/utils/AppHeader.test.tsx
+++ b/__tests__/components/utils/AppHeader.test.tsx
@@ -40,7 +40,7 @@ describe('AppHeader', () => {
 
     const heading = screen.getByText(/FQM Testify: an ECQM Analysis Tool/i);
     expect(heading).toBeInTheDocument();
-    const mbName = screen.getByText(MOCK_MEASURE_BUNDLE.name);
+    const mbName = screen.getByText(MOCK_MEASURE_BUNDLE.fileName);
     expect(mbName).toBeInTheDocument();
     const dateString = screen.getByText(/January 1, 2020 - January 1, 2021/i);
     expect(dateString).toBeInTheDocument();

--- a/__tests__/components/utils/MeasureUploadHeader.test.tsx
+++ b/__tests__/components/utils/MeasureUploadHeader.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { RouterContext } from 'next/dist/shared/lib/router-context';
-import MeasureUploadHeader from '../../../components/utils/MeasureUploadHeader';
+import MeasureUploadHeader from '../../../components/utils/MeasureFileUploadHeader';
 import { createMockRouter, mantineRecoilWrap } from '../../helpers/testHelpers';
 
 describe('MeasureUploadHeader', () => {

--- a/__tests__/components/utils/MeasureUploadHeader.test.tsx
+++ b/__tests__/components/utils/MeasureUploadHeader.test.tsx
@@ -14,7 +14,9 @@ describe('MeasureUploadHeader', () => {
       )
     );
 
-    const measureUploadHeader = screen.getByText(/Step 1: Upload a Measure Bundle/i);
+    const stepHeader = screen.getByText(/Step 1:/i);
+    const measureUploadHeader = screen.getByText(/Upload a Measure Bundle/i);
+    expect(stepHeader).toBeInTheDocument();
     expect(measureUploadHeader).toBeInTheDocument();
   });
 

--- a/__tests__/components/utils/UploadErrorInfo.test.tsx
+++ b/__tests__/components/utils/UploadErrorInfo.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { MeasureUploadError } from '../../../components/measure-upload/MeasureUpload';
+import { MeasureUploadError } from '../../../components/measure-upload/MeasureFileUpload';
 import UploadErrorInfo from '../../../components/utils/UploadErrorInfo';
 import { mantineRecoilWrap } from '../../helpers/testHelpers';
 

--- a/__tests__/components/utils/UploadErrorInfo.test.tsx
+++ b/__tests__/components/utils/UploadErrorInfo.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { MeasureUploadError } from '../../../util/MeasureUploadUtils';
+import { MeasureUploadError } from '../../../util/measureUploadUtils';
 import UploadErrorInfo from '../../../components/utils/UploadErrorInfo';
 import { mantineRecoilWrap } from '../../helpers/testHelpers';
 

--- a/__tests__/components/utils/UploadErrorInfo.test.tsx
+++ b/__tests__/components/utils/UploadErrorInfo.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { MeasureUploadError } from '../../../components/measure-upload/MeasureFileUpload';
+import { MeasureUploadError } from '../../../util/MeasureUploadUtils';
 import UploadErrorInfo from '../../../components/utils/UploadErrorInfo';
 import { mantineRecoilWrap } from '../../helpers/testHelpers';
 
@@ -8,7 +8,7 @@ const MOCK_SIMPLE_ERROR: MeasureUploadError = {
   id: 'simple-error',
   message: 'this is a simple error',
   timestamp: '1996-07-19T20:12:00.0Z',
-  attemptedFileName: 'fake-bundle.json',
+  attemptedBundleDisplay: 'fake-bundle.json',
   isValueSetMissingError: false
 };
 
@@ -16,7 +16,7 @@ const MOCK_VALUESET_ERROR: MeasureUploadError = {
   id: 'valueset-error',
   message: ['http://example.com/ValueSet/1', 'http://example.com/ValueSet/2'],
   timestamp: '1996-07-19T20:12:00.0Z',
-  attemptedFileName: 'fake-bundle.json',
+  attemptedBundleDisplay: 'fake-bundle.json',
   isValueSetMissingError: true
 };
 
@@ -24,7 +24,7 @@ describe('UploadErrorInfo', () => {
   it('should render file name and timestamp of error', () => {
     render(mantineRecoilWrap(<UploadErrorInfo error={MOCK_SIMPLE_ERROR} />));
 
-    expect(screen.getByText(MOCK_SIMPLE_ERROR.attemptedFileName)).toBeInTheDocument();
+    expect(screen.getByText(MOCK_SIMPLE_ERROR.attemptedBundleDisplay as string)).toBeInTheDocument();
     expect(screen.getByText(MOCK_SIMPLE_ERROR.timestamp)).toBeInTheDocument();
   });
 

--- a/__tests__/components/utils/UploadErrorInfo.test.tsx
+++ b/__tests__/components/utils/UploadErrorInfo.test.tsx
@@ -9,7 +9,8 @@ const MOCK_SIMPLE_ERROR: MeasureUploadError = {
   message: 'this is a simple error',
   timestamp: '1996-07-19T20:12:00.0Z',
   attemptedBundleDisplay: 'fake-bundle.json',
-  isValueSetMissingError: false
+  isValueSetMissingError: false,
+  isThrownFromMrs: false
 };
 
 const MOCK_VALUESET_ERROR: MeasureUploadError = {
@@ -17,7 +18,8 @@ const MOCK_VALUESET_ERROR: MeasureUploadError = {
   message: ['http://example.com/ValueSet/1', 'http://example.com/ValueSet/2'],
   timestamp: '1996-07-19T20:12:00.0Z',
   attemptedBundleDisplay: 'fake-bundle.json',
-  isValueSetMissingError: true
+  isValueSetMissingError: true,
+  isThrownFromMrs: false
 };
 
 describe('UploadErrorInfo', () => {

--- a/__tests__/utils/MeasureUpload.test.ts
+++ b/__tests__/utils/MeasureUpload.test.ts
@@ -1,4 +1,7 @@
-import { populateMeasurementPeriod, DEFAULT_MEASUREMENT_PERIOD } from '../../components/measure-upload/MeasureUpload';
+import {
+  populateMeasurementPeriod,
+  DEFAULT_MEASUREMENT_PERIOD
+} from '../../components/measure-upload/MeasureFileUpload';
 import { DateTime } from 'luxon';
 
 const EXAMPLE_START_DATE = '2020-01-01';

--- a/__tests__/utils/measureUploadUtils.test.ts
+++ b/__tests__/utils/measureUploadUtils.test.ts
@@ -1,7 +1,4 @@
-import {
-  populateMeasurementPeriod,
-  DEFAULT_MEASUREMENT_PERIOD
-} from '../../components/measure-upload/MeasureFileUpload';
+import { populateMeasurementPeriod, DEFAULT_MEASUREMENT_PERIOD } from '../../util/MeasureUploadUtils';
 import { DateTime } from 'luxon';
 
 const EXAMPLE_START_DATE = '2020-01-01';

--- a/__tests__/utils/measureUploadUtils.test.ts
+++ b/__tests__/utils/measureUploadUtils.test.ts
@@ -1,4 +1,4 @@
-import { populateMeasurementPeriod, DEFAULT_MEASUREMENT_PERIOD } from '../../util/MeasureUploadUtils';
+import { populateMeasurementPeriod, DEFAULT_MEASUREMENT_PERIOD } from '../../util/measureUploadUtils';
 import { DateTime } from 'luxon';
 
 const EXAMPLE_START_DATE = '2020-01-01';

--- a/components/measure-upload/MeasureFileUpload.tsx
+++ b/components/measure-upload/MeasureFileUpload.tsx
@@ -6,10 +6,7 @@ import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { v4 as uuidv4 } from 'uuid';
 import { measureBundleState } from '../../state/atoms/measureBundle';
 import { measurementPeriodState } from '../../state/atoms/measurementPeriod';
-import { DateTime } from 'luxon';
-import { Calculator } from 'fqm-execution';
-
-const VSAC_REGEX = /http:\/\/cts\.nlm\.nih\.gov.*ValueSet/;
+import { MeasureUploadProps, identifyMissingValueSets, populateMeasurementPeriod } from '../../util/MeasureUploadUtils';
 
 const useStyles = createStyles({
   text: {
@@ -17,26 +14,7 @@ const useStyles = createStyles({
   }
 });
 
-export const DEFAULT_MEASUREMENT_PERIOD = {
-  start: DateTime.fromISO('2022-01-01').toJSDate(),
-  end: DateTime.fromISO('2022-12-31').toJSDate()
-};
-
-const DEFAULT_MEASUREMENT_PERIOD_DURATION = 1;
-
-export interface MeasureUploadError {
-  id: string;
-  message: string | string[];
-  timestamp: string;
-  attemptedFileName: string;
-  isValueSetMissingError: boolean;
-}
-
-export interface MeasureUploadProps {
-  logError: (error: MeasureUploadError) => void;
-}
-
-export default function MeasureUpload({ logError }: MeasureUploadProps) {
+export default function MeasureFileUpload({ logError }: MeasureUploadProps) {
   const setMeasureBundle = useSetRecoilState(measureBundleState);
   const setMeasurementPeriod = useSetRecoilState(measurementPeriodState);
 
@@ -86,7 +64,7 @@ export default function MeasureUpload({ logError }: MeasureUploadProps) {
       id: uuidv4(),
       message,
       timestamp: new Date().toISOString(),
-      attemptedFileName: fileName,
+      attemptedBundleDisplay: fileName,
       isValueSetMissingError
     });
     showNotification({
@@ -140,67 +118,4 @@ function DropzoneChildren() {
       </Stack>
     </Grid>
   );
-}
-
-/**
- * Takes in two date strings and populates a valid measurement period with JS Dates
- * as start and end points
- * @param startString{String} Signifies the date of measurement period start
- * @param endString{String} Signifies the date of measurement period end
- * @returns {Object} an object a JS Date from period start and end
- */
-export function populateMeasurementPeriod(
-  startString: string | undefined,
-  endString: string | undefined
-): { start: Date; end: Date } {
-  const measurementPeriod = { ...DEFAULT_MEASUREMENT_PERIOD };
-
-  if (startString) {
-    const startDate = DateTime.fromISO(startString).toJSDate();
-    measurementPeriod.start = startDate;
-    // Measurement period start and end are both defined
-    if (endString) {
-      measurementPeriod.end = DateTime.fromISO(endString).toJSDate();
-      // If start is defined and end isn't, make the period last one year from the start
-    } else {
-      const newEnd = new Date(startDate);
-      newEnd.setFullYear(startDate.getFullYear() + DEFAULT_MEASUREMENT_PERIOD_DURATION);
-      measurementPeriod.end = newEnd;
-    }
-
-    // If end is defined and start isn't, make the period start one year from the end
-  } else if (endString) {
-    const endDate = DateTime.fromISO(endString).toJSDate();
-    measurementPeriod.end = endDate;
-    const newStart = new Date(endDate);
-    newStart.setFullYear(endDate.getFullYear() - DEFAULT_MEASUREMENT_PERIOD_DURATION);
-    measurementPeriod.start = newStart;
-  }
-  return measurementPeriod;
-}
-
-/**
- * Runs data requirements on a FHIR MeasureBundle, then compares the required
- * valuesets to the valuesets included in the bundle. Returns an array of canonical urls of
- * missing required valuesets
- */
-async function identifyMissingValueSets(mb: fhir4.Bundle): Promise<string[]> {
-  const allRequiredValuesets = new Set<string>();
-  const includedValuesets = new Set<string>();
-
-  mb?.entry?.forEach(e => {
-    if (e?.resource?.resourceType === 'ValueSet') {
-      includedValuesets.add(e.resource.url as string);
-    }
-  });
-  const dataRequirements = await Calculator.calculateDataRequirements(mb);
-  dataRequirements?.results?.dataRequirement?.forEach(dr => {
-    dr?.codeFilter?.forEach(filter => {
-      if (filter.valueSet && VSAC_REGEX.test(filter.valueSet)) {
-        allRequiredValuesets.add(filter.valueSet as string);
-      }
-    });
-  });
-  const missingValuesets = Array.from(allRequiredValuesets).filter(vs => !includedValuesets.has(vs));
-  return missingValuesets;
 }

--- a/components/measure-upload/MeasureFileUpload.tsx
+++ b/components/measure-upload/MeasureFileUpload.tsx
@@ -6,7 +6,7 @@ import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { v4 as uuidv4 } from 'uuid';
 import { measureBundleState } from '../../state/atoms/measureBundle';
 import { measurementPeriodState } from '../../state/atoms/measurementPeriod';
-import { MeasureUploadProps, identifyMissingValueSets, populateMeasurementPeriod } from '../../util/MeasureUploadUtils';
+import { MeasureUploadProps, identifyMissingValueSets, populateMeasurementPeriod } from '../../util/measureUploadUtils';
 
 const useStyles = createStyles({
   text: {

--- a/components/measure-upload/MeasureFileUpload.tsx
+++ b/components/measure-upload/MeasureFileUpload.tsx
@@ -98,10 +98,19 @@ function DropzoneChildren() {
     <Grid justify="center" align="center" style={{ minHeight: 200 }}>
       <Stack>
         <Center>
-          {measureBundle.fileName && measureBundle.isFile ? <IconFileCheck size={80} /> : <IconFileImport size={80} />}
+          {measureBundle.fileName && measureBundle.isFile ? (
+            <IconFileCheck size={80} color="green" />
+          ) : (
+            <IconFileImport size={80} />
+          )}
         </Center>
         <Center>
-          <Text size="xl" inline className={classes.text}>
+          <Text
+            size="xl"
+            inline
+            className={classes.text}
+            style={{ color: measureBundle.fileName && measureBundle.isFile ? 'green' : 'black' }}
+          >
             {measureBundle.fileName && measureBundle.isFile
               ? measureBundle.fileName
               : 'Drag a Measure Bundle JSON file here or click to select files'}

--- a/components/measure-upload/MeasureRepositoryUpload.tsx
+++ b/components/measure-upload/MeasureRepositoryUpload.tsx
@@ -58,7 +58,7 @@ export default function MeasureRepositoryUpload({ logError }: MeasureUploadProps
 
   /**
    * Handles updating of the Measure Repository Service url field and associated state variables
-  */
+   */
   function handleMrsUrlChange(event: React.ChangeEvent<HTMLInputElement>) {
     if (measureSelectIsOpen) {
       setMeasureSelectIsOpen(false);
@@ -76,7 +76,7 @@ export default function MeasureRepositoryUpload({ logError }: MeasureUploadProps
   /**
    * Takes the entries from a Measure retrieval response and creates a map from Measure id
    * to Measure display label for Measure select component
-  */
+   */
   function createMeasureDisplayMap(
     displayMap: Record<string, string>,
     { resource: measure }: { resource: fhir4.Measure }
@@ -100,7 +100,7 @@ export default function MeasureRepositoryUpload({ logError }: MeasureUploadProps
   /**
    * Sends a `GET` request to the `/Measure` endpoint of the specified Measure Repository Service.
    * Parses and stores the measureIds if successful
-  */
+   */
   async function retrieveMeasures() {
     setIsLoadingIds(true);
     let parsedMeasureRepositoryUrl = measureRepositoryUrl;
@@ -150,7 +150,7 @@ export default function MeasureRepositoryUpload({ logError }: MeasureUploadProps
   /**
    * Sends a `POST` request to the `Measure/:id/$package` endpoint of the specified Measure
    * Repository Service. Checks the resulting bundle is valid and saves it if so.
-  */
+   */
   async function retrieveMeasurePackage(id: string) {
     setMeasureBundle(mb => ({ ...mb, selectedMeasureId: id }));
     if (id) {

--- a/components/measure-upload/MeasureRepositoryUpload.tsx
+++ b/components/measure-upload/MeasureRepositoryUpload.tsx
@@ -1,13 +1,22 @@
-import { Button, Collapse, Group, Select, TextInput } from '@mantine/core';
+import { Button, Collapse, Grid, Group, Loader, Select, TextInput } from '@mantine/core';
 import React, { useState } from 'react';
 import { useEffect } from 'react';
-import { useRecoilState, useSetRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import { measureBundleState } from '../../state/atoms/measureBundle';
 import { measurementPeriodState } from '../../state/atoms/measurementPeriod';
 import { identifyMissingValueSets, MeasureUploadProps, populateMeasurementPeriod } from '../../util/MeasureUploadUtils';
 import { showNotification } from '@mantine/notifications';
 import { v4 as uuidv4 } from 'uuid';
 import { IconAlertCircle } from '@tabler/icons';
+import { CircleCheck } from 'tabler-icons-react';
+import { displayMapToSelectDataState } from '../../state/selectors/displayMapToSelectData';
+
+enum PACKAGE_STATES {
+  LOADING,
+  SUCCESS,
+  FAIL,
+  NONE
+}
 
 const MEASURE_RETRIEVAL_BODY = {
   resourceType: 'Parameters',
@@ -26,21 +35,22 @@ const MEASURE_RETRIEVAL_OPTIONS = {
 };
 
 export default function MeasureRepositoryUpload({ logError }: MeasureUploadProps) {
-  const [mrsUrl, setMrsUrl] = useState('');
-  const [measureIds, setMeasureIds] = useState([]);
-  const [selectedId, setSelectedId] = useState<string | null>(null);
-
-  const [measureBundle, setMeasureBundle] = useRecoilState(measureBundleState);
-  const setMeasurementPeriod = useSetRecoilState(measurementPeriodState);
-
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoadingIds, setIsLoadingIds] = useState(false);
+  const [isLoadingPackage, setIsLoadingPackage] = useState<PACKAGE_STATES>(PACKAGE_STATES.NONE);
   const [measureSelectIsOpen, setMeasureSelectIsOpen] = useState(false);
 
+  const [{ measureRepositoryUrl, isFile, selectedMeasureId, displayMap }, setMeasureBundle] =
+    useRecoilState(measureBundleState);
+  const setMeasurementPeriod = useSetRecoilState(measurementPeriodState);
+
+  const idSelectData = useRecoilValue(displayMapToSelectDataState);
+
   useEffect(() => {
-    if (mrsUrl && selectedId) {
-      retrieveMeasurePackage();
+    if (isFile) {
+      setMeasureSelectIsOpen(false);
+      setIsLoadingPackage(PACKAGE_STATES.NONE);
     }
-  }, [selectedId]);
+  }, [isFile]);
 
   const rejectUpload = (
     message: string | string[],
@@ -60,28 +70,62 @@ export default function MeasureRepositoryUpload({ logError }: MeasureUploadProps
       message: 'There was an issue uploading your bundle. Please correct the issues listed below.',
       color: 'red'
     });
-    setMeasureBundle({
-      name: '',
-      content: null
-    });
+    setIsLoadingPackage(PACKAGE_STATES.FAIL);
   };
 
+  /*
+    Handles updating of the Measure Repository Service url field and associated state variables
+  */
   function handleMrsUrlChange(event: React.ChangeEvent<HTMLInputElement>) {
-    setMrsUrl(event.currentTarget.value);
     if (measureSelectIsOpen) {
-      setMeasureIds([]);
       setMeasureSelectIsOpen(false);
     }
+    setMeasureBundle(mb => ({
+      ...mb,
+      measureRepositoryUrl: event.currentTarget.value,
+      selectedMeasureId: null,
+      displayMap: {},
+      ...(!mb.isFile ? { content: null } : undefined)
+    }));
+    setIsLoadingPackage(PACKAGE_STATES.NONE);
   }
 
-  async function retrieveMeasureIds() {
-    setIsLoading(true);
+  /*
+    Takes the entries from a Measure retrieval response and creates a map from Measure id
+    to Measure display label for Measure select component
+  */
+  function createMeasureDisplayMap(
+    displayMap: Record<string, string>,
+    { resource: measure }: { resource: fhir4.Measure }
+  ) {
+    let label: string;
+    const officialIdentifier = measure.identifier?.find(
+      identifier =>
+        identifier.use === 'official' && identifier.system === 'http://hl7.org/fhir/cqi/ecqm/Measure/Identifier/cms'
+    );
+    if (officialIdentifier?.value) {
+      label = measure.version ? `${officialIdentifier.value}|${measure.version}` : officialIdentifier.value;
+    } else if (measure.name) {
+      label = measure.version ? `${measure.name}|${measure.version}` : measure.name;
+    } else {
+      label = measure.id as string;
+    }
+    displayMap[measure.id as string] = label;
+    return displayMap;
+  }
+
+  /*
+    Sends a `GET` request to the `/Measure` endpoint of the specified Measure Repository Service.
+    Parses and stores the measureIds if successful
+  */
+  async function retrieveMeasures() {
+    setIsLoadingIds(true);
     try {
-      const response = await fetch(`${mrsUrl}/Measure`);
+      const response = await fetch(`${measureRepositoryUrl}/Measure`);
       const responseBody = await response.json();
       if (response.status === 200) {
-        const ids = responseBody.entry.map((e: fhir4.BundleEntry) => e.resource?.id);
-        setMeasureIds(ids);
+        const displayMap = responseBody.entry.reduce(createMeasureDisplayMap, {});
+        setMeasureBundle(mb => ({ ...mb, displayMap }));
         if (!measureSelectIsOpen) {
           setMeasureSelectIsOpen(true);
         }
@@ -97,45 +141,57 @@ export default function MeasureRepositoryUpload({ logError }: MeasureUploadProps
       showNotification({
         icon: <IconAlertCircle />,
         title: 'Failed reaching out to server',
-        message: `Could not connect to server with url: ${mrsUrl}`,
+        message: `Could not connect to server with url: ${measureRepositoryUrl}`,
         color: 'red'
       });
     }
-    setIsLoading(false);
+    setIsLoadingIds(false);
   }
 
-  async function retrieveMeasurePackage() {
-    const response = await fetch(`${mrsUrl}/Measure/${selectedId}/$package`, MEASURE_RETRIEVAL_OPTIONS);
-    const responseBody = await response.json();
-    if (responseBody.resourceType !== 'Bundle') {
-      if (responseBody.resourceType === 'OperationOutcome') {
-        rejectUpload(
-          `Packaging of Measure: ${selectedId} failed with message: "${responseBody.issue[0].details.text}"`,
-          selectedId
-        );
-      } else {
-        rejectUpload("Uploaded file must be a JSON FHIR Resource of type 'Bundle'", selectedId);
+  /*
+    Sends a `POST` request to the `Measure/:id/$package` endpoint of the specified Measure
+    Repository Service. Checks the resulting bundle is valid and saves it if so.
+  */
+  async function retrieveMeasurePackage(id: string) {
+    setMeasureBundle(mb => ({ ...mb, selectedMeasureId: id }));
+    if (id) {
+      const display = displayMap[id];
+      setIsLoadingPackage(PACKAGE_STATES.LOADING);
+      const response = await fetch(`${measureRepositoryUrl}/Measure/${id}/$package`, MEASURE_RETRIEVAL_OPTIONS);
+      const responseBody = await response.json();
+      if (responseBody.resourceType !== 'Bundle') {
+        if (responseBody.resourceType === 'OperationOutcome') {
+          rejectUpload(
+            `Packaging of Measure: ${display} failed with message: "${responseBody.issue[0].details.text}"`,
+            display
+          );
+        } else {
+          rejectUpload("Uploaded file must be a JSON FHIR Resource of type 'Bundle'", display);
+        }
+        return;
       }
-      return;
-    }
 
-    const measures = responseBody.entry.filter((e: fhir4.BundleEntry) => e.resource?.resourceType === 'Measure');
-    if (measures.length !== 1) {
-      rejectUpload(`Expected exactly 1 Measure in uploaded Bundle, received: ${measures.length}`, selectedId);
-      return;
-    }
+      const measures = responseBody.entry.filter((e: fhir4.BundleEntry) => e.resource?.resourceType === 'Measure');
+      if (measures.length !== 1) {
+        rejectUpload(`Expected exactly 1 Measure in uploaded Bundle, received: ${measures.length}`, display);
+        return;
+      }
 
-    const missingValueSets = await identifyMissingValueSets(responseBody);
-    if (missingValueSets.length > 0) {
-      rejectUpload(missingValueSets, selectedId, true);
-      return;
-    }
-    const effectivePeriod = ((measures as fhir4.BundleEntry[])[0].resource as fhir4.Measure).effectivePeriod;
+      const missingValueSets = await identifyMissingValueSets(responseBody);
+      if (missingValueSets.length > 0) {
+        rejectUpload(missingValueSets, display, true);
+        return;
+      }
+      const effectivePeriod = ((measures as fhir4.BundleEntry[])[0].resource as fhir4.Measure).effectivePeriod;
 
-    // Set measurement period to default period
-    const measurementPeriod = populateMeasurementPeriod(effectivePeriod?.start, effectivePeriod?.end);
-    setMeasureBundle({ name: selectedId as string, content: responseBody });
-    setMeasurementPeriod(measurementPeriod);
+      // Set measurement period to default period
+      const measurementPeriod = populateMeasurementPeriod(effectivePeriod?.start, effectivePeriod?.end);
+      setMeasureBundle(mb => ({ ...mb, content: responseBody, isFile: false }));
+      setMeasurementPeriod(measurementPeriod);
+      setIsLoadingPackage(PACKAGE_STATES.SUCCESS);
+    } else {
+      setIsLoadingPackage(PACKAGE_STATES.NONE);
+    }
   }
 
   return (
@@ -144,26 +200,35 @@ export default function MeasureRepositoryUpload({ logError }: MeasureUploadProps
         <TextInput
           label="Measure Repository Service URL"
           placeholder="http://example.com"
-          value={mrsUrl}
+          value={measureRepositoryUrl}
           onChange={handleMrsUrlChange}
           style={{ flex: 1 }}
         />
-        <Button onClick={retrieveMeasureIds} loading={isLoading}>
+        <Button onClick={retrieveMeasures} loading={isLoadingIds}>
           Get Measures
         </Button>
       </Group>
-      <Collapse in={measureSelectIsOpen}>
-        <Select
-          label="Measure ID"
-          data={measureIds}
-          disabled={measureIds.length === 0}
-          value={selectedId}
-          onChange={setSelectedId}
-          placeholder="Select ID"
-          searchable
-          clearable
-          nothingFound={'No options matching search'}
-        ></Select>
+      <Collapse in={measureSelectIsOpen || (selectedMeasureId !== null && measureRepositoryUrl !== '')}>
+        <Grid>
+          <Grid.Col span={11}>
+            <Select
+              label="Measure ID"
+              data={idSelectData}
+              disabled={idSelectData.length === 0}
+              value={selectedMeasureId}
+              onChange={retrieveMeasurePackage}
+              placeholder="Select ID"
+              searchable
+              clearable
+              nothingFound={'No options matching search'}
+            />
+          </Grid.Col>
+          <Grid.Col span={1} style={{ display: 'flex', alignItems: 'end', justifyContent: 'center' }}>
+            {isLoadingPackage === PACKAGE_STATES.LOADING && <Loader />}
+            {isLoadingPackage === PACKAGE_STATES.SUCCESS && <CircleCheck color="green" size={40} />}
+            {isLoadingPackage === PACKAGE_STATES.FAIL && <IconAlertCircle color="red" size={40} />}
+          </Grid.Col>
+        </Grid>
       </Collapse>
     </div>
   );

--- a/components/measure-upload/MeasureRepositoryUpload.tsx
+++ b/components/measure-upload/MeasureRepositoryUpload.tsx
@@ -56,8 +56,8 @@ export default function MeasureRepositoryUpload({ logError }: MeasureUploadProps
     }
   }, [isFile]);
 
-  /*
-    Handles updating of the Measure Repository Service url field and associated state variables
+  /**
+   * Handles updating of the Measure Repository Service url field and associated state variables
   */
   function handleMrsUrlChange(event: React.ChangeEvent<HTMLInputElement>) {
     if (measureSelectIsOpen) {
@@ -73,9 +73,9 @@ export default function MeasureRepositoryUpload({ logError }: MeasureUploadProps
     setIsLoadingPackage(PACKAGE_STATES.NONE);
   }
 
-  /*
-    Takes the entries from a Measure retrieval response and creates a map from Measure id
-    to Measure display label for Measure select component
+  /**
+   * Takes the entries from a Measure retrieval response and creates a map from Measure id
+   * to Measure display label for Measure select component
   */
   function createMeasureDisplayMap(
     displayMap: Record<string, string>,
@@ -97,9 +97,9 @@ export default function MeasureRepositoryUpload({ logError }: MeasureUploadProps
     return displayMap;
   }
 
-  /*
-    Sends a `GET` request to the `/Measure` endpoint of the specified Measure Repository Service.
-    Parses and stores the measureIds if successful
+  /**
+   * Sends a `GET` request to the `/Measure` endpoint of the specified Measure Repository Service.
+   * Parses and stores the measureIds if successful
   */
   async function retrieveMeasures() {
     setIsLoadingIds(true);
@@ -147,9 +147,9 @@ export default function MeasureRepositoryUpload({ logError }: MeasureUploadProps
     setIsLoadingIds(false);
   }
 
-  /*
-    Sends a `POST` request to the `Measure/:id/$package` endpoint of the specified Measure
-    Repository Service. Checks the resulting bundle is valid and saves it if so.
+  /**
+   * Sends a `POST` request to the `Measure/:id/$package` endpoint of the specified Measure
+   * Repository Service. Checks the resulting bundle is valid and saves it if so.
   */
   async function retrieveMeasurePackage(id: string) {
     setMeasureBundle(mb => ({ ...mb, selectedMeasureId: id }));

--- a/components/measure-upload/MeasureRepositoryUpload.tsx
+++ b/components/measure-upload/MeasureRepositoryUpload.tsx
@@ -4,7 +4,7 @@ import { useEffect } from 'react';
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import { measureBundleState } from '../../state/atoms/measureBundle';
 import { measurementPeriodState } from '../../state/atoms/measurementPeriod';
-import { identifyMissingValueSets, MeasureUploadProps, populateMeasurementPeriod } from '../../util/MeasureUploadUtils';
+import { identifyMissingValueSets, MeasureUploadProps, populateMeasurementPeriod } from '../../util/measureUploadUtils';
 import { showNotification } from '@mantine/notifications';
 import { v4 as uuidv4 } from 'uuid';
 import { IconAlertCircle } from '@tabler/icons';

--- a/components/measure-upload/MeasureRepositoryUpload.tsx
+++ b/components/measure-upload/MeasureRepositoryUpload.tsx
@@ -1,0 +1,170 @@
+import { Button, Collapse, Group, Select, TextInput } from '@mantine/core';
+import React, { useState } from 'react';
+import { useEffect } from 'react';
+import { useRecoilState, useSetRecoilState } from 'recoil';
+import { measureBundleState } from '../../state/atoms/measureBundle';
+import { measurementPeriodState } from '../../state/atoms/measurementPeriod';
+import { identifyMissingValueSets, MeasureUploadProps, populateMeasurementPeriod } from '../../util/MeasureUploadUtils';
+import { showNotification } from '@mantine/notifications';
+import { v4 as uuidv4 } from 'uuid';
+import { IconAlertCircle } from '@tabler/icons';
+
+const MEASURE_RETRIEVAL_BODY = {
+  resourceType: 'Parameters',
+  parameter: [
+    {
+      name: 'include-terminology',
+      valueBoolean: true
+    }
+  ]
+};
+
+const MEASURE_RETRIEVAL_OPTIONS = {
+  method: 'POST',
+  body: JSON.stringify(MEASURE_RETRIEVAL_BODY),
+  headers: { 'Content-Type': 'application/json+fhir' }
+};
+
+export default function MeasureRepositoryUpload({ logError }: MeasureUploadProps) {
+  const [mrsUrl, setMrsUrl] = useState('');
+  const [measureIds, setMeasureIds] = useState([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const [measureBundle, setMeasureBundle] = useRecoilState(measureBundleState);
+  const setMeasurementPeriod = useSetRecoilState(measurementPeriodState);
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [measureSelectIsOpen, setMeasureSelectIsOpen] = useState(false);
+
+  useEffect(() => {
+    if (mrsUrl && selectedId) {
+      retrieveMeasurePackage();
+    }
+  }, [selectedId]);
+
+  const rejectUpload = (
+    message: string | string[],
+    attemptedBundleDisplay: string | null,
+    isValueSetMissingError = false
+  ) => {
+    logError({
+      id: uuidv4(),
+      message,
+      timestamp: new Date().toISOString(),
+      attemptedBundleDisplay,
+      isValueSetMissingError
+    });
+    showNotification({
+      icon: <IconAlertCircle />,
+      title: 'Bundle upload failed',
+      message: 'There was an issue uploading your bundle. Please correct the issues listed below.',
+      color: 'red'
+    });
+    setMeasureBundle({
+      name: '',
+      content: null
+    });
+  };
+
+  function handleMrsUrlChange(event: React.ChangeEvent<HTMLInputElement>) {
+    setMrsUrl(event.currentTarget.value);
+    if (measureSelectIsOpen) {
+      setMeasureIds([]);
+      setMeasureSelectIsOpen(false);
+    }
+  }
+
+  async function retrieveMeasureIds() {
+    setIsLoading(true);
+    try {
+      const response = await fetch(`${mrsUrl}/Measure`);
+      const responseBody = await response.json();
+      if (response.status === 200) {
+        const ids = responseBody.entry.map((e: fhir4.BundleEntry) => e.resource?.id);
+        setMeasureIds(ids);
+        if (!measureSelectIsOpen) {
+          setMeasureSelectIsOpen(true);
+        }
+      } else {
+        showNotification({
+          icon: <IconAlertCircle />,
+          title: 'Failed reaching out to server',
+          message: `Server responded with code: ${response.status}:${response.statusText}`,
+          color: 'red'
+        });
+      }
+    } catch (e) {
+      showNotification({
+        icon: <IconAlertCircle />,
+        title: 'Failed reaching out to server',
+        message: `Could not connect to server with url: ${mrsUrl}`,
+        color: 'red'
+      });
+    }
+    setIsLoading(false);
+  }
+
+  async function retrieveMeasurePackage() {
+    const response = await fetch(`${mrsUrl}/Measure/${selectedId}/$package`, MEASURE_RETRIEVAL_OPTIONS);
+    const responseBody = await response.json();
+    if (responseBody.resourceType !== 'Bundle') {
+      if (responseBody.resourceType === 'OperationOutcome') {
+        rejectUpload(
+          `Packaging of Measure: ${selectedId} failed with message: "${responseBody.issue[0].details.text}"`,
+          selectedId
+        );
+      } else {
+        rejectUpload("Uploaded file must be a JSON FHIR Resource of type 'Bundle'", selectedId);
+      }
+      return;
+    }
+
+    const measures = responseBody.entry.filter((e: fhir4.BundleEntry) => e.resource?.resourceType === 'Measure');
+    if (measures.length !== 1) {
+      rejectUpload(`Expected exactly 1 Measure in uploaded Bundle, received: ${measures.length}`, selectedId);
+      return;
+    }
+
+    const missingValueSets = await identifyMissingValueSets(responseBody);
+    if (missingValueSets.length > 0) {
+      rejectUpload(missingValueSets, selectedId, true);
+      return;
+    }
+    const effectivePeriod = ((measures as fhir4.BundleEntry[])[0].resource as fhir4.Measure).effectivePeriod;
+
+    // Set measurement period to default period
+    const measurementPeriod = populateMeasurementPeriod(effectivePeriod?.start, effectivePeriod?.end);
+    setMeasureBundle({ name: selectedId as string, content: responseBody });
+    setMeasurementPeriod(measurementPeriod);
+  }
+
+  return (
+    <div>
+      <Group position="apart" style={{ alignItems: 'flex-end' }}>
+        <TextInput
+          label="Measure Repository Service URL"
+          placeholder="http://example.com"
+          value={mrsUrl}
+          onChange={handleMrsUrlChange}
+          style={{ flex: 1 }}
+        />
+        <Button onClick={retrieveMeasureIds} loading={isLoading}>
+          Get Measures
+        </Button>
+      </Group>
+      <Collapse in={measureSelectIsOpen}>
+        <Select
+          label="Measure ID"
+          data={measureIds}
+          disabled={measureIds.length === 0}
+          value={selectedId}
+          onChange={setSelectedId}
+          placeholder="Select ID"
+          searchable
+          clearable
+          nothingFound={'No options matching search'}
+        ></Select>
+      </Collapse>
+    </div>
+  );
+}

--- a/components/measure-upload/UploadErrorLog.tsx
+++ b/components/measure-upload/UploadErrorLog.tsx
@@ -1,6 +1,6 @@
 import { Center, ScrollArea, Stack, Text } from '@mantine/core';
 import React from 'react';
-import { MeasureUploadError } from '../../util/MeasureUploadUtils';
+import { MeasureUploadError } from '../../util/measureUploadUtils';
 import UploadErrorInfo from '../utils/UploadErrorInfo';
 
 export interface UploadErrorLogProps {

--- a/components/measure-upload/UploadErrorLog.tsx
+++ b/components/measure-upload/UploadErrorLog.tsx
@@ -1,7 +1,7 @@
 import { Center, ScrollArea, Stack, Text } from '@mantine/core';
 import React from 'react';
+import { MeasureUploadError } from '../../util/MeasureUploadUtils';
 import UploadErrorInfo from '../utils/UploadErrorInfo';
-import { MeasureUploadError } from './MeasureUpload';
 
 export interface UploadErrorLogProps {
   uploadSuccess: boolean;

--- a/components/patient-creation/PatientCreationPanel.tsx
+++ b/components/patient-creation/PatientCreationPanel.tsx
@@ -224,7 +224,11 @@ function PatientCreationPanel() {
     // Build zip file
     const zip = new JSZip();
     const dateCreated = new Date();
-    const fileNameString = `${measureBundle.name.replace('.json', '')}-test-cases`;
+    const fileNameString = `${
+      measureBundle.isFile
+        ? measureBundle.fileName.replace('.json', '')
+        : measureBundle.displayMap[measureBundle.selectedMeasureId as string]
+    }-test-cases`;
     const measureBundleFolder = zip.folder(fileNameString);
     if (measureBundleFolder) {
       Object.keys(currentPatients).forEach(id => {

--- a/components/utils/AppHeader.tsx
+++ b/components/utils/AppHeader.tsx
@@ -29,7 +29,9 @@ export default function AppHeader() {
             <div style={{ display: 'flex', justifyContent: 'space-around', gap: 10, alignItems: 'center' }}>
               <div>
                 <Text size="md" color="dimmed">
-                  {measureBundle.name}
+                  {measureBundle.isFile
+                    ? measureBundle.fileName
+                    : measureBundle.displayMap[measureBundle.selectedMeasureId as string]}
                 </Text>
                 <Text size="sm" color="dimmed">
                   {retrieveMeasurementPeriodString(start, end)}

--- a/components/utils/DateSelectorsHeader.tsx
+++ b/components/utils/DateSelectorsHeader.tsx
@@ -6,7 +6,10 @@ export default function DateSelectorsHeader() {
     <Group>
       <div style={{ paddingRight: 5 }}>
         <Text size="xl" weight={700}>
-          Step 2: Set your Measurement Period Date Range
+          Step 2:
+        </Text>
+        <Text size="lg" weight={400}>
+          Set your Measurement Period Date Range
         </Text>
       </div>
     </Group>

--- a/components/utils/MeasureFileUploadHeader.tsx
+++ b/components/utils/MeasureFileUploadHeader.tsx
@@ -2,17 +2,20 @@ import { Text, Popover, List, Anchor, ActionIcon, Group } from '@mantine/core';
 import React, { useState } from 'react';
 import { InfoCircle } from 'tabler-icons-react';
 
-export default function MeasureUploadHeader() {
+export default function MeasureFileUploadHeader() {
   const [opened, setOpened] = useState(false);
 
   return (
-    <Group>
-      <div style={{ paddingRight: 5 }}>
+    <div>
+      <div style={{ paddingRight: 4 }}>
         <Text size="xl" weight={700}>
-          Step 1: Upload a Measure Bundle
+          Step 1:
         </Text>
       </div>
-      <div>
+      <Group>
+        <Text size="lg" weight={400}>
+          Upload a Measure Bundle
+        </Text>
         <Popover opened={opened} onClose={() => setOpened(false)}>
           <Popover.Target>
             <ActionIcon aria-label={'More Information'} onClick={() => setOpened(o => !o)}>
@@ -34,7 +37,7 @@ export default function MeasureUploadHeader() {
             </List>
           </Popover.Dropdown>
         </Popover>
-      </div>
-    </Group>
+      </Group>
+    </div>
   );
 }

--- a/components/utils/MeasureRespositoryUploadHeader.tsx
+++ b/components/utils/MeasureRespositoryUploadHeader.tsx
@@ -1,4 +1,4 @@
-import { Text, Popover, List, Anchor, ActionIcon, Group } from '@mantine/core';
+import { Text, Popover, Anchor, ActionIcon, Group } from '@mantine/core';
 import React, { useState } from 'react';
 import { InfoCircle } from 'tabler-icons-react';
 
@@ -22,12 +22,15 @@ export default function MeasureRepositoryUploadHeader() {
               <InfoCircle size={20} />
             </ActionIcon>
           </Popover.Target>
-          <Popover.Dropdown>
-            Enter the base URL for a Measure Repository Service server. The server must support the{' '}
-            <Anchor href="https://build.fhir.org/ig/HL7/cqf-measures/measure-repository-service.html#package">
-              $package
-            </Anchor>{' '}
-            operation for Measure resources with the "include-terminology" parameter.
+          <Popover.Dropdown style={{ width: '300px' }}>
+            <Text>Enter the base URL for a Measure Repository Service server.</Text>
+            <Text>
+              The server must support the{' '}
+              <Anchor href="https://build.fhir.org/ig/HL7/cqf-measures/measure-repository-service.html#package">
+                $package
+              </Anchor>{' '}
+              operation for Measure resources with the &quot;include-terminology&quot; parameter.
+            </Text>
           </Popover.Dropdown>
         </Popover>
       </Group>

--- a/components/utils/MeasureRespositoryUploadHeader.tsx
+++ b/components/utils/MeasureRespositoryUploadHeader.tsx
@@ -1,0 +1,36 @@
+import { Text, Popover, List, Anchor, ActionIcon, Group } from '@mantine/core';
+import React, { useState } from 'react';
+import { InfoCircle } from 'tabler-icons-react';
+
+export default function MeasureRepositoryUploadHeader() {
+  const [opened, setOpened] = useState(false);
+
+  return (
+    <Group>
+      <div style={{ paddingRight: 4, justifyContent: 'center', width: '100%' }}>
+        <Text size="xl" weight={700} style={{ textAlign: 'center' }}>
+          OR
+        </Text>
+      </div>
+      <Group style={{ paddingRight: 4 }}>
+        <Text size="lg" weight={400}>
+          Retrieve Measure from Measure Repository Service
+        </Text>
+        <Popover opened={opened} onClose={() => setOpened(false)}>
+          <Popover.Target>
+            <ActionIcon aria-label={'More Information'} onClick={() => setOpened(o => !o)}>
+              <InfoCircle size={20} />
+            </ActionIcon>
+          </Popover.Target>
+          <Popover.Dropdown>
+            Enter the base URL for a Measure Repository Service server. The server must support the{' '}
+            <Anchor href="https://build.fhir.org/ig/HL7/cqf-measures/measure-repository-service.html#package">
+              $package
+            </Anchor>{' '}
+            operation for Measure resources with the "include-terminology" parameter.
+          </Popover.Dropdown>
+        </Popover>
+      </Group>
+    </Group>
+  );
+}

--- a/components/utils/MeasureRespositoryUploadHeader.tsx
+++ b/components/utils/MeasureRespositoryUploadHeader.tsx
@@ -23,7 +23,13 @@ export default function MeasureRepositoryUploadHeader() {
             </ActionIcon>
           </Popover.Target>
           <Popover.Dropdown style={{ width: '300px' }}>
-            <Text>Enter the base URL for a Measure Repository Service server.</Text>
+            <Text>
+              Enter the base URL for a{' '}
+              <Anchor href="https://build.fhir.org/ig/HL7/cqf-measures/measure-repository-service.html">
+                Measure Repository Service
+              </Anchor>{' '}
+              server.
+            </Text>
             <Text>
               The server must support the{' '}
               <Anchor href="https://build.fhir.org/ig/HL7/cqf-measures/measure-repository-service.html#package">

--- a/components/utils/UploadErrorInfo.tsx
+++ b/components/utils/UploadErrorInfo.tsx
@@ -24,8 +24,16 @@ export default function UploadErrorInfo({ error }: UploadErrorInfoProps) {
               justifyContent: 'space-between'
             }}
           >
-            <Text>Bundle is missing required ValueSets</Text>
-            <Button variant="subtle" color="gray" onClick={() => setIsDetailOpen(!isDetailOpen)} style={{}}>
+            <div>
+              <Text>Bundle is missing required ValueSets.</Text>
+              {error.isThrownFromMrs && (
+                <Text>
+                  A VS API Key must be specified by the Measure Repository Service server to retrieve the missing
+                  ValueSets.
+                </Text>
+              )}
+            </div>
+            <Button variant="subtle" color="gray" onClick={() => setIsDetailOpen(!isDetailOpen)}>
               {isDetailOpen ? 'Hide ' : 'Show '}Missing ValueSet URLs
             </Button>
           </div>

--- a/components/utils/UploadErrorInfo.tsx
+++ b/components/utils/UploadErrorInfo.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Button, Collapse, Group, Paper, Text } from '@mantine/core';
-import { MeasureUploadError } from '../measure-upload/MeasureUpload';
 import Link from 'next/link';
+import { MeasureUploadError } from '../../util/MeasureUploadUtils';
 
 export interface UploadErrorInfoProps {
   error: MeasureUploadError;
@@ -13,7 +13,7 @@ export default function UploadErrorInfo({ error }: UploadErrorInfoProps) {
   return (
     <Paper withBorder shadow="md" p="md">
       <Group spacing="xs">
-        <Text weight={600}>{error.attemptedFileName}</Text>
+        <Text weight={600}>{error.attemptedBundleDisplay}</Text>
         <Text color="dimmed">{error.timestamp}</Text>
       </Group>
       {error.isValueSetMissingError ? (

--- a/components/utils/UploadErrorInfo.tsx
+++ b/components/utils/UploadErrorInfo.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Button, Collapse, Group, Paper, Text } from '@mantine/core';
 import Link from 'next/link';
-import { MeasureUploadError } from '../../util/MeasureUploadUtils';
+import { MeasureUploadError } from '../../util/measureUploadUtils';
 
 export interface UploadErrorInfoProps {
   error: MeasureUploadError;

--- a/fixtures/test/measureBundle.ts
+++ b/fixtures/test/measureBundle.ts
@@ -1,5 +1,9 @@
 export const MOCK_MEASURE_BUNDLE = {
-  name: 'measureBundle',
+  fileName: 'measureBundle',
+  isFile: true,
+  displayMap: {},
+  selectedMeasureId: null,
+  measureRepositoryUrl: '',
   content: {
     resourceType: 'Bundle',
     type: 'collection',

--- a/package-lock.json
+++ b/package-lock.json
@@ -590,6 +590,7 @@
       "version": "7.17.9",
       "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.17.9.tgz",
       "integrity": "sha512-WxYHHUWF2uZ7Hp1K+D1xQgbgkGUfA+5UPOegEXGt2Y5SMog/rYCVaifLZDbw8UkNXozEqqrZTy6bglL7xTaCOw==",
+      "dev": true,
       "dependencies": {
         "core-js-pure": "^3.20.2",
         "regenerator-runtime": "^0.13.4"
@@ -3727,6 +3728,7 @@
       "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.22.5.tgz",
       "integrity": "sha512-8xo9R00iYD7TcV7OrC98GwxiUEAabVWO3dix+uyWjnYrx9fyASLlIX+f/3p5dW5qByaP2bcZ8X/T47s55et/tA==",
       "deprecated": "core-js-pure@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js-pure.",
+      "dev": true,
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -3754,40 +3756,30 @@
       }
     },
     "node_modules/cql-exec-fhir": {
-      "version": "2.0.2",
-      "resolved": "git+https://git@github.com/projecttacoma/cql-exec-fhir.git#d48d57c3c7e199cbaa02e41418cad9efcd148b15",
-      "license": "Apache-2.0",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/cql-exec-fhir/-/cql-exec-fhir-2.1.3.tgz",
+      "integrity": "sha512-UxGpZlvQHCd1Pl47J+J01SsvxBucbRGF1pFqlITw62e2YT3PDDdV4s7ZNfQ1Yy2TigSwITmajnSH0tOZuT4mvQ==",
       "dependencies": {
-        "@babel/runtime": "^7.17.2",
-        "@babel/runtime-corejs3": "^7.17.2",
-        "axios": "^0.26.0",
         "xml2js": "~0.4.23"
       },
       "peerDependencies": {
-        "cql-execution": ">=1.3.0"
-      }
-    },
-    "node_modules/cql-exec-fhir/node_modules/axios": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-      "dependencies": {
-        "follow-redirects": "^1.14.8"
+        "cql-execution": ">=1.3.0 || ^3.0.0-beta"
       }
     },
     "node_modules/cql-execution": {
-      "version": "2.4.0",
-      "resolved": "git+https://git@github.com/projecttacoma/cql-execution.git#d1c0e9341c763bb8cc641a5a702cedb0c8385c88",
-      "license": "Apache-2.0",
+      "version": "3.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.0-beta.3.tgz",
+      "integrity": "sha512-Mcr3vUilXfnz2qooyKzKZT3lexWTo/U7ktwt3DXnAFfsKfCYBe4zHyGv9ThRwW7OFMM/mr5LmM4szbm2StSfZw==",
       "dependencies": {
         "@lhncbc/ucum-lhc": "^4.1.3",
-        "luxon": "^1.25.0"
+        "immutable": "^4.1.0",
+        "luxon": "^1.28.1"
       }
     },
     "node_modules/cql-execution/node_modules/luxon": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.0.tgz",
-      "integrity": "sha512-TfTiyvZhwBYM/7QdAVDh+7dBTBA29v4ik0Ce9zda3Mnf8on1S5KJI8P2jKFZ8+5C0jhmr0KwJEO/Wdpm0VeWJQ==",
+      "version": "1.28.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.1.tgz",
+      "integrity": "sha512-gYHAa180mKrNIUJCbwpmD0aTu9kV0dREDrwNnuyFAsO1Wt0EVYSZelPnJlbj9HplzXX/YWXHFTL45kvZ53M0pw==",
       "engines": {
         "node": "*"
       }
@@ -5157,16 +5149,16 @@
       }
     },
     "node_modules/fqm-execution": {
-      "version": "1.0.0-beta.5",
-      "resolved": "git+https://git@github.com/projecttacoma/fqm-execution.git#428a720ed737819a375dfe5e989f34552108304b",
+      "version": "1.0.6",
+      "resolved": "git+https://git@github.com/projecttacoma/fqm-execution.git#bfa3a4454f56bb2eabf6f325c80faa41fd96b3b3",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/fhir": "0.0.34",
         "atob": "^2.1.2",
         "axios": "^0.21.1",
         "commander": "^6.1.0",
-        "cql-exec-fhir": "git+https://git@github.com/projecttacoma/cql-exec-fhir",
-        "cql-execution": "git+https://git@github.com/projecttacoma/cql-execution",
+        "cql-exec-fhir": "^2.1.3",
+        "cql-execution": "^3.0.0-beta.3",
         "handlebars": "^4.7.7",
         "lodash": "^4.17.21",
         "moment": "^2.29.4",
@@ -5620,6 +5612,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
       }
+    },
+    "node_modules/immutable": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.2.4.tgz",
+      "integrity": "sha512-WDxL3Hheb1JkRN3sQkyujNlL/xRjAo3rJtaU5xeufUauG66JdMr32bLj4gF+vWl84DIA3Zxw7tiAjneYzRRw+w=="
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -9491,6 +9488,7 @@
       "version": "7.17.9",
       "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.17.9.tgz",
       "integrity": "sha512-WxYHHUWF2uZ7Hp1K+D1xQgbgkGUfA+5UPOegEXGt2Y5SMog/rYCVaifLZDbw8UkNXozEqqrZTy6bglL7xTaCOw==",
+      "dev": true,
       "requires": {
         "core-js-pure": "^3.20.2",
         "regenerator-runtime": "^0.13.4"
@@ -11889,7 +11887,8 @@
     "core-js-pure": {
       "version": "3.22.5",
       "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.22.5.tgz",
-      "integrity": "sha512-8xo9R00iYD7TcV7OrC98GwxiUEAabVWO3dix+uyWjnYrx9fyASLlIX+f/3p5dW5qByaP2bcZ8X/T47s55et/tA=="
+      "integrity": "sha512-8xo9R00iYD7TcV7OrC98GwxiUEAabVWO3dix+uyWjnYrx9fyASLlIX+f/3p5dW5qByaP2bcZ8X/T47s55et/tA==",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.3",
@@ -11909,37 +11908,27 @@
       }
     },
     "cql-exec-fhir": {
-      "version": "git+https://git@github.com/projecttacoma/cql-exec-fhir.git#d48d57c3c7e199cbaa02e41418cad9efcd148b15",
-      "from": "cql-exec-fhir@git+https://git@github.com/projecttacoma/cql-exec-fhir",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/cql-exec-fhir/-/cql-exec-fhir-2.1.3.tgz",
+      "integrity": "sha512-UxGpZlvQHCd1Pl47J+J01SsvxBucbRGF1pFqlITw62e2YT3PDDdV4s7ZNfQ1Yy2TigSwITmajnSH0tOZuT4mvQ==",
       "requires": {
-        "@babel/runtime": "^7.17.2",
-        "@babel/runtime-corejs3": "^7.17.2",
-        "axios": "^0.26.0",
         "xml2js": "~0.4.23"
-      },
-      "dependencies": {
-        "axios": {
-          "version": "0.26.1",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-          "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-          "requires": {
-            "follow-redirects": "^1.14.8"
-          }
-        }
       }
     },
     "cql-execution": {
-      "version": "git+https://git@github.com/projecttacoma/cql-execution.git#d1c0e9341c763bb8cc641a5a702cedb0c8385c88",
-      "from": "cql-execution@>=1.3.0",
+      "version": "3.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.0-beta.3.tgz",
+      "integrity": "sha512-Mcr3vUilXfnz2qooyKzKZT3lexWTo/U7ktwt3DXnAFfsKfCYBe4zHyGv9ThRwW7OFMM/mr5LmM4szbm2StSfZw==",
       "requires": {
         "@lhncbc/ucum-lhc": "^4.1.3",
-        "luxon": "^1.25.0"
+        "immutable": "^4.1.0",
+        "luxon": "^1.28.1"
       },
       "dependencies": {
         "luxon": {
-          "version": "1.28.0",
-          "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.0.tgz",
-          "integrity": "sha512-TfTiyvZhwBYM/7QdAVDh+7dBTBA29v4ik0Ce9zda3Mnf8on1S5KJI8P2jKFZ8+5C0jhmr0KwJEO/Wdpm0VeWJQ=="
+          "version": "1.28.1",
+          "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.1.tgz",
+          "integrity": "sha512-gYHAa180mKrNIUJCbwpmD0aTu9kV0dREDrwNnuyFAsO1Wt0EVYSZelPnJlbj9HplzXX/YWXHFTL45kvZ53M0pw=="
         }
       }
     },
@@ -13013,15 +13002,15 @@
       }
     },
     "fqm-execution": {
-      "version": "git+https://git@github.com/projecttacoma/fqm-execution.git#428a720ed737819a375dfe5e989f34552108304b",
+      "version": "git+https://git@github.com/projecttacoma/fqm-execution.git#bfa3a4454f56bb2eabf6f325c80faa41fd96b3b3",
       "from": "fqm-execution@git+https://git@github.com/projecttacoma/fqm-execution",
       "requires": {
         "@types/fhir": "0.0.34",
         "atob": "^2.1.2",
         "axios": "^0.21.1",
         "commander": "^6.1.0",
-        "cql-exec-fhir": "git+https://git@github.com/projecttacoma/cql-exec-fhir",
-        "cql-execution": "git+https://git@github.com/projecttacoma/cql-execution",
+        "cql-exec-fhir": "^2.1.3",
+        "cql-execution": "^3.0.0-beta.3",
         "handlebars": "^4.7.7",
         "lodash": "^4.17.21",
         "moment": "^2.29.4",
@@ -13344,6 +13333,11 @@
       "version": "9.0.14",
       "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.14.tgz",
       "integrity": "sha512-ubBeqQutOSLIFCUBN03jGeOS6a3DoYlSYwYJTa+gSKEZKU5redJIqkIdZ3JVv/4RZpfcXdAWH5zCNLWPRv2WDw=="
+    },
+    "immutable": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.2.4.tgz",
+      "integrity": "sha512-WDxL3Hheb1JkRN3sQkyujNlL/xRjAo3rJtaU5xeufUauG66JdMr32bLj4gF+vWl84DIA3Zxw7tiAjneYzRRw+w=="
     },
     "import-fresh": {
       "version": "3.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3767,9 +3767,9 @@
       }
     },
     "node_modules/cql-execution": {
-      "version": "3.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.0-beta.3.tgz",
-      "integrity": "sha512-Mcr3vUilXfnz2qooyKzKZT3lexWTo/U7ktwt3DXnAFfsKfCYBe4zHyGv9ThRwW7OFMM/mr5LmM4szbm2StSfZw==",
+      "version": "3.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.0-beta.4.tgz",
+      "integrity": "sha512-TWAVtdZEr0h/P7CXRV+DBdPRdougBkG30AgXg/N8Xz4upbmc4zNTg2cfAAvMbJrsYl5sqZbJFcUvxaGcTZGjqw==",
       "dependencies": {
         "@lhncbc/ucum-lhc": "^4.1.3",
         "immutable": "^4.1.0",
@@ -5149,8 +5149,8 @@
       }
     },
     "node_modules/fqm-execution": {
-      "version": "1.0.6",
-      "resolved": "git+https://git@github.com/projecttacoma/fqm-execution.git#bfa3a4454f56bb2eabf6f325c80faa41fd96b3b3",
+      "version": "1.0.8",
+      "resolved": "git+https://git@github.com/projecttacoma/fqm-execution.git#bf9fc23735dad7bf0114229537e29acffee86bad",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/fhir": "0.0.34",
@@ -5158,7 +5158,7 @@
         "axios": "^0.21.1",
         "commander": "^6.1.0",
         "cql-exec-fhir": "^2.1.3",
-        "cql-execution": "^3.0.0-beta.3",
+        "cql-execution": "^3.0.0-beta.4",
         "handlebars": "^4.7.7",
         "lodash": "^4.17.21",
         "moment": "^2.29.4",
@@ -11916,9 +11916,9 @@
       }
     },
     "cql-execution": {
-      "version": "3.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.0-beta.3.tgz",
-      "integrity": "sha512-Mcr3vUilXfnz2qooyKzKZT3lexWTo/U7ktwt3DXnAFfsKfCYBe4zHyGv9ThRwW7OFMM/mr5LmM4szbm2StSfZw==",
+      "version": "3.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.0-beta.4.tgz",
+      "integrity": "sha512-TWAVtdZEr0h/P7CXRV+DBdPRdougBkG30AgXg/N8Xz4upbmc4zNTg2cfAAvMbJrsYl5sqZbJFcUvxaGcTZGjqw==",
       "requires": {
         "@lhncbc/ucum-lhc": "^4.1.3",
         "immutable": "^4.1.0",
@@ -13002,7 +13002,7 @@
       }
     },
     "fqm-execution": {
-      "version": "git+https://git@github.com/projecttacoma/fqm-execution.git#bfa3a4454f56bb2eabf6f325c80faa41fd96b3b3",
+      "version": "git+https://git@github.com/projecttacoma/fqm-execution.git#bf9fc23735dad7bf0114229537e29acffee86bad",
       "from": "fqm-execution@git+https://git@github.com/projecttacoma/fqm-execution",
       "requires": {
         "@types/fhir": "0.0.34",
@@ -13010,7 +13010,7 @@
         "axios": "^0.21.1",
         "commander": "^6.1.0",
         "cql-exec-fhir": "^2.1.3",
-        "cql-execution": "^3.0.0-beta.3",
+        "cql-execution": "^3.0.0-beta.4",
         "handlebars": "^4.7.7",
         "lodash": "^4.17.21",
         "moment": "^2.29.4",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -12,7 +12,7 @@ import MeasureRepositoryUploadHeader from '../components/utils/MeasureRespositor
 import DateSelectorsHeader from '../components/utils/DateSelectorsHeader';
 import UploadErrorLog from '../components/measure-upload/UploadErrorLog';
 import MeasureRepositoryUpload from '../components/measure-upload/MeasureRepositoryUpload';
-import { MeasureUploadError } from '../util/MeasureUploadUtils';
+import { MeasureUploadError } from '../util/measureUploadUtils';
 
 const Home: NextPage = () => {
   const measureBundle = useRecoilValue(measureBundleState);

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -56,7 +56,7 @@ const Home: NextPage = () => {
                   sx={() => ({
                     marginTop: 10
                   })}
-                  disabled={!(measureBundle.name && measurementPeriod.start && measurementPeriod.end)}
+                  disabled={!(measureBundle.content && measurementPeriod.start && measurementPeriod.end)}
                 >
                   Next
                 </Button>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,15 +1,18 @@
 import type { NextPage } from 'next';
 import Link from 'next/link';
-import { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Button, Grid, Group, Space, Stack } from '@mantine/core';
 import { useRecoilValue } from 'recoil';
-import MeasureUpload, { MeasureUploadError } from '../components/measure-upload/MeasureUpload';
+import MeasureFileUpload from '../components/measure-upload/MeasureFileUpload';
 import DateSelectors from '../components/measure-upload/DateSelectors';
 import { measureBundleState } from '../state/atoms/measureBundle';
 import { measurementPeriodState } from '../state/atoms/measurementPeriod';
-import MeasureUploadHeader from '../components/utils/MeasureUploadHeader';
+import MeasureFileUploadHeader from '../components/utils/MeasureFileUploadHeader';
+import MeasureRepositoryUploadHeader from '../components/utils/MeasureRespositoryUploadHeader';
 import DateSelectorsHeader from '../components/utils/DateSelectorsHeader';
 import UploadErrorLog from '../components/measure-upload/UploadErrorLog';
+import MeasureRepositoryUpload from '../components/measure-upload/MeasureRepositoryUpload';
+import { MeasureUploadError } from '../util/MeasureUploadUtils';
 
 const Home: NextPage = () => {
   const measureBundle = useRecoilValue(measureBundleState);
@@ -39,8 +42,10 @@ const Home: NextPage = () => {
       <Grid justify="center">
         <Grid.Col span={5}>
           <Stack justify="space-evenly" spacing="xl">
-            <MeasureUploadHeader />
-            <MeasureUpload logError={logError} />
+            <MeasureFileUploadHeader />
+            <MeasureFileUpload logError={logError} />
+            <MeasureRepositoryUploadHeader />
+            <MeasureRepositoryUpload logError={logError} />
             <Space />
             <DateSelectorsHeader />
             <DateSelectors />

--- a/state/atoms/measureBundle.ts
+++ b/state/atoms/measureBundle.ts
@@ -1,8 +1,12 @@
 import { atom } from 'recoil';
 
 interface MeasureBundleStateType {
-  name: string;
   content: fhir4.Bundle | null;
+  displayMap: Record<string, string>;
+  fileName: string;
+  isFile: boolean;
+  measureRepositoryUrl: string;
+  selectedMeasureId: string | null;
 }
 
 /**
@@ -11,7 +15,11 @@ interface MeasureBundleStateType {
 export const measureBundleState = atom<MeasureBundleStateType>({
   key: 'measureBundleState',
   default: {
-    name: '',
-    content: null
+    content: null,
+    displayMap: {},
+    fileName: '',
+    isFile: false,
+    measureRepositoryUrl: '',
+    selectedMeasureId: null
   }
 });

--- a/state/selectors/displayMapToSelectData.ts
+++ b/state/selectors/displayMapToSelectData.ts
@@ -1,0 +1,10 @@
+import { selector } from 'recoil';
+import { measureBundleState } from '../atoms/measureBundle';
+
+export const displayMapToSelectDataState = selector<Record<'label' | 'value', string>[]>({
+  key: 'displayMapToSelectDataState',
+  get: ({ get }) => {
+    const measureBundle = get(measureBundleState);
+    return Object.keys(measureBundle.displayMap).map(id => ({ value: id, label: measureBundle.displayMap[id] }));
+  }
+});

--- a/util/measureUploadUtils.ts
+++ b/util/measureUploadUtils.ts
@@ -13,7 +13,7 @@ export interface MeasureUploadProps {
   logError: (error: MeasureUploadError) => void;
 }
 
-const DEFAULT_MEASUREMENT_PERIOD = {
+export const DEFAULT_MEASUREMENT_PERIOD = {
   start: DateTime.fromISO('2022-01-01').toJSDate(),
   end: DateTime.fromISO('2022-12-31').toJSDate()
 };

--- a/util/measureUploadUtils.ts
+++ b/util/measureUploadUtils.ts
@@ -1,0 +1,83 @@
+import { Calculator } from 'fqm-execution';
+import { DateTime } from 'luxon';
+
+export interface MeasureUploadError {
+  id: string;
+  message: string | string[];
+  timestamp: string;
+  attemptedBundleDisplay: string | null;
+  isValueSetMissingError: boolean;
+}
+
+export interface MeasureUploadProps {
+  logError: (error: MeasureUploadError) => void;
+}
+
+const DEFAULT_MEASUREMENT_PERIOD = {
+  start: DateTime.fromISO('2022-01-01').toJSDate(),
+  end: DateTime.fromISO('2022-12-31').toJSDate()
+};
+
+const DEFAULT_MEASUREMENT_PERIOD_DURATION = 1;
+
+const VSAC_REGEX = /http:\/\/cts\.nlm\.nih\.gov.*ValueSet/;
+
+/**
+ * Takes in two date strings and populates a valid measurement period with JS Dates
+ * as start and end points
+ */
+export function populateMeasurementPeriod(
+  startString: string | undefined,
+  endString: string | undefined
+): { start: Date; end: Date } {
+  const measurementPeriod = { ...DEFAULT_MEASUREMENT_PERIOD };
+
+  if (startString) {
+    const startDate = DateTime.fromISO(startString).toJSDate();
+    measurementPeriod.start = startDate;
+    // Measurement period start and end are both defined
+    if (endString) {
+      measurementPeriod.end = DateTime.fromISO(endString).toJSDate();
+      // If start is defined and end isn't, make the period last one year from the start
+    } else {
+      const newEnd = new Date(startDate);
+      newEnd.setFullYear(startDate.getFullYear() + DEFAULT_MEASUREMENT_PERIOD_DURATION);
+      measurementPeriod.end = newEnd;
+    }
+
+    // If end is defined and start isn't, make the period start one year from the end
+  } else if (endString) {
+    const endDate = DateTime.fromISO(endString).toJSDate();
+    measurementPeriod.end = endDate;
+    const newStart = new Date(endDate);
+    newStart.setFullYear(endDate.getFullYear() - DEFAULT_MEASUREMENT_PERIOD_DURATION);
+    measurementPeriod.start = newStart;
+  }
+  return measurementPeriod;
+}
+
+/**
+ * Runs data requirements on a FHIR MeasureBundle, then compares the required
+ * valuesets to the valuesets included in the bundle. Returns an array of canonical urls of
+ * missing required valuesets
+ */
+export async function identifyMissingValueSets(mb: fhir4.Bundle): Promise<string[]> {
+  const allRequiredValuesets = new Set<string>();
+  const includedValuesets = new Set<string>();
+
+  mb?.entry?.forEach(e => {
+    if (e?.resource?.resourceType === 'ValueSet') {
+      includedValuesets.add(e.resource.url as string);
+    }
+  });
+  const dataRequirements = await Calculator.calculateDataRequirements(mb);
+  dataRequirements?.results?.dataRequirement?.forEach(dr => {
+    dr?.codeFilter?.forEach(filter => {
+      if (filter.valueSet && VSAC_REGEX.test(filter.valueSet)) {
+        allRequiredValuesets.add(filter.valueSet as string);
+      }
+    });
+  });
+  const missingValuesets = Array.from(allRequiredValuesets).filter(vs => !includedValuesets.has(vs));
+  return missingValuesets;
+}

--- a/util/measureUploadUtils.tsx
+++ b/util/measureUploadUtils.tsx
@@ -1,5 +1,8 @@
+import { showNotification } from '@mantine/notifications';
 import { Calculator } from 'fqm-execution';
 import { DateTime } from 'luxon';
+import { v4 as uuidv4 } from 'uuid';
+import { IconAlertCircle } from '@tabler/icons';
 
 export interface MeasureUploadError {
   id: string;
@@ -7,11 +10,14 @@ export interface MeasureUploadError {
   timestamp: string;
   attemptedBundleDisplay: string | null;
   isValueSetMissingError: boolean;
+  isThrownFromMrs: boolean;
 }
 
 export interface MeasureUploadProps {
-  logError: (error: MeasureUploadError) => void;
+  logError: LogErrorType;
 }
+
+type LogErrorType = (error: MeasureUploadError) => void;
 
 export const DEFAULT_MEASUREMENT_PERIOD = {
   start: DateTime.fromISO('2022-01-01').toJSDate(),
@@ -21,6 +27,29 @@ export const DEFAULT_MEASUREMENT_PERIOD = {
 const DEFAULT_MEASUREMENT_PERIOD_DURATION = 1;
 
 const VSAC_REGEX = /http:\/\/cts\.nlm\.nih\.gov.*ValueSet/;
+
+export const rejectUpload = (
+  message: string | string[],
+  attemptedBundleDisplay: string | null,
+  logError: LogErrorType,
+  isThrownFromMrs = false,
+  isValueSetMissingError = false
+) => {
+  logError({
+    id: uuidv4(),
+    message,
+    timestamp: new Date().toISOString(),
+    attemptedBundleDisplay,
+    isValueSetMissingError,
+    isThrownFromMrs
+  });
+  showNotification({
+    icon: <IconAlertCircle />,
+    title: 'Bundle upload failed',
+    message: 'There was an issue uploading your bundle. Please correct the issues listed below.',
+    color: 'red'
+  });
+};
 
 /**
  * Takes in two date strings and populates a valid measurement period with JS Dates


### PR DESCRIPTION
# Summary
FQM-Testify can now import a Measure from a passed in Measure Repository Service URL

## New Behavior
All old behavior should be unchanged!
There is now a new option on the Measure Upload page to upload from Measure Repository Service
The app should work identically once a valid Measure is uploaded through this new method.

## Code Changes

- Created MeasureRepositoryUpload.tsx, a component that pulls measures from a MRS and then packages the selected measure with all dependencies into a Measure Bundle to pass into testify
- Created MeasureRepositoryHeader.tsx, a component that frames the above component and adds helpful information
- Created displayMapToSelectData Selector to populate Measure Select component.
- Added additional information to MeasureBundleState to determine the type of upload and persist information for both file and MRS sourced upload when leaving/returning to the page
- Minor updates to other components that access MeasureBundleState to accommodate these changes
- Minor updates to existing tests to accommodate changes

# Testing Guidance
- `npm run check`
- Run through the regular file upload workflow and ensure nothing has changed
- Start up our Measure Repository Service and upload as many valid and invalid bundles as you'd like
- Start up Testify with `npm run dev`
- Type in the url of the running measure repository service and ensure the call is successful and the measure select dropdown appears and is populated accurately
- Select a working measure and ensure that Testify workflow is unchanged from there
- Select a broken measure and ensure that the error handling is intuitive and properly labeled
- Try to break the system. Move back and forth between screens. Upload a file when a bundle is already uploaded through MRS and vice versa. Change the url after uploading a bundle. Make sure the code works intuitively throughout the process.
