### PR TITLE
Use calculate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FQM Testify
 
-Tooling for analysis of FHIR-based Electronic Clinical Quality Measures (eCQMs).
+Tooling for analysis of Electronic Clinical Quality Measures (eCQMs) based on the HL7® FHIR® standard<sup id="fn-1">[\[1\]](#fnref-1)</sup>.
 
 - [Installation](#installation)
 
@@ -125,3 +125,7 @@ http://www.apache.org/licenses/LICENSE-2.0
 ```
 
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+---
+
+<strong id="fnref-1">[\[1\]](#fn-1) FHIR® is the registered trademark of Health Level Seven International (HL7). </strong>

--- a/__tests__/components/calculation/PopulationCalculation.test.tsx
+++ b/__tests__/components/calculation/PopulationCalculation.test.tsx
@@ -4,10 +4,11 @@ import { measureBundleState } from '../../../state/atoms/measureBundle';
 import { patientTestCaseState } from '../../../state/atoms/patientTestCase';
 import { getMockRecoilState, mantineRecoilWrap } from '../../helpers/testHelpers';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { Calculator, CalculatorTypes } from 'fqm-execution';
+import { Calculator } from 'fqm-execution';
 import MeasureUpload from '../../../components/measure-upload/MeasureFileUpload';
+import { DetailedResult } from '../../../util/types';
 
-const MOCK_DETAILED_RESULT: CalculatorTypes.ExecutionResult<CalculatorTypes.DetailedPopulationGroupResult> = {
+const MOCK_DETAILED_RESULT: DetailedResult = {
   patientId: '',
   detailedResults: [
     {

--- a/__tests__/components/calculation/PopulationCalculation.test.tsx
+++ b/__tests__/components/calculation/PopulationCalculation.test.tsx
@@ -4,22 +4,19 @@ import { measureBundleState } from '../../../state/atoms/measureBundle';
 import { patientTestCaseState } from '../../../state/atoms/patientTestCase';
 import { getMockRecoilState, mantineRecoilWrap } from '../../helpers/testHelpers';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { Calculator, MeasureReportBuilder } from 'fqm-execution';
+import { Calculator, CalculatorTypes } from 'fqm-execution';
 import MeasureUpload from '../../../components/measure-upload/MeasureFileUpload';
 
-const MOCK_MEASURE_REPORT: fhir4.MeasureReport = {
-  resourceType: 'MeasureReport',
-  type: 'individual',
-  status: 'complete',
-  measure: '',
-  period: {
-    start: '',
-    end: ''
-  },
-  text: {
-    div: 'test123',
-    status: 'additional'
-  }
+const MOCK_DETAILED_RESULT: CalculatorTypes.ExecutionResult<CalculatorTypes.DetailedPopulationGroupResult> = {
+  patientId: '',
+  detailedResults: [
+    {
+      groupId: '',
+      statementResults: [],
+      populationResults: [],
+      html: 'test123'
+    }
+  ]
 };
 
 const MOCK_BUNDLE: fhir4.Bundle = {
@@ -136,12 +133,8 @@ describe('PopulationCalculation', () => {
       }
     });
 
-    jest.spyOn(MeasureReportBuilder, 'buildMeasureReports').mockImplementation(() => {
-      return [MOCK_MEASURE_REPORT];
-    });
-
     jest.spyOn(Calculator, 'calculate').mockResolvedValue({
-      results: []
+      results: [MOCK_DETAILED_RESULT]
     });
 
     await act(async () => {
@@ -206,12 +199,8 @@ describe('PopulationCalculation', () => {
       }
     });
 
-    jest.spyOn(MeasureReportBuilder, 'buildMeasureReports').mockImplementation(() => {
-      return [MOCK_MEASURE_REPORT];
-    });
-
     jest.spyOn(Calculator, 'calculate').mockResolvedValue({
-      results: []
+      results: [MOCK_DETAILED_RESULT]
     });
 
     await act(async () => {
@@ -276,12 +265,8 @@ describe('PopulationCalculation', () => {
       }
     });
 
-    jest.spyOn(MeasureReportBuilder, 'buildMeasureReports').mockImplementation(() => {
-      return [MOCK_MEASURE_REPORT];
-    });
-
     jest.spyOn(Calculator, 'calculate').mockResolvedValue({
-      results: []
+      results: [MOCK_DETAILED_RESULT]
     });
 
     await act(async () => {

--- a/__tests__/components/calculation/PopulationComparisonTable.test.tsx
+++ b/__tests__/components/calculation/PopulationComparisonTable.test.tsx
@@ -6,10 +6,11 @@ import { measureBundleState } from '../../../state/atoms/measureBundle';
 import { patientTestCaseState, TestCase } from '../../../state/atoms/patientTestCase';
 import { selectedPatientState } from '../../../state/atoms/selectedPatient';
 import { getMockRecoilState, mantineRecoilWrap } from '../../helpers/testHelpers';
-import { CalculatorTypes, Enums } from 'fqm-execution';
+import { Enums } from 'fqm-execution';
 import { detailedResultLookupState } from '../../../state/atoms/detailedResultLookup';
+import { DetailedResult } from '../../../util/types';
 
-const MOCK_DETAILED_RESULT: CalculatorTypes.ExecutionResult<CalculatorTypes.DetailedPopulationGroupResult> = {
+const MOCK_DETAILED_RESULT: DetailedResult = {
   patientId: 'example-pt',
   detailedResults: [
     {
@@ -113,10 +114,7 @@ const MEASURE_BUNDLE_POPULATED = {
   selectedMeasureId: null
 };
 
-const MOCK_DETAILED_RESULT_LOOKUP: Record<
-  string,
-  CalculatorTypes.ExecutionResult<CalculatorTypes.DetailedPopulationGroupResult>
-> = {
+const MOCK_DETAILED_RESULT_LOOKUP: Record<string, DetailedResult> = {
   'example-pt': MOCK_DETAILED_RESULT
 };
 

--- a/__tests__/components/calculation/PopulationComparisonTable.test.tsx
+++ b/__tests__/components/calculation/PopulationComparisonTable.test.tsx
@@ -1,75 +1,25 @@
 import '@testing-library/jest-dom';
 import { act, render, screen } from '@testing-library/react';
-import { MeasureReport } from 'fhir/r4';
 import { Suspense } from 'react';
 import PopulationComparisonTable from '../../../components/calculation/PopulationComparisonTable';
 import { measureBundleState } from '../../../state/atoms/measureBundle';
-import { measureReportLookupState } from '../../../state/atoms/measureReportLookup';
 import { patientTestCaseState, TestCase } from '../../../state/atoms/patientTestCase';
 import { selectedPatientState } from '../../../state/atoms/selectedPatient';
 import { getMockRecoilState, mantineRecoilWrap } from '../../helpers/testHelpers';
+import { CalculatorTypes, Enums } from 'fqm-execution';
+import { detailedResultLookupState } from '../../../state/atoms/detailedResultLookup';
 
-const MOCK_MEASURE_REPORT: fhir4.MeasureReport = {
-  resourceType: 'MeasureReport',
-  type: 'individual',
-  status: 'complete',
-  measure: '',
-  period: {
-    start: '',
-    end: ''
-  },
-  group: [
+const MOCK_DETAILED_RESULT: CalculatorTypes.ExecutionResult<CalculatorTypes.DetailedPopulationGroupResult> = {
+  patientId: 'example-pt',
+  detailedResults: [
     {
-      id: '',
-      population: [
-        {
-          count: 1,
-          code: {
-            coding: [
-              {
-                system: '',
-                code: 'initial-population',
-                display: 'Initial Population'
-              }
-            ]
-          }
-        },
-        {
-          count: 1,
-          code: {
-            coding: [
-              {
-                system: '',
-                code: 'numerator',
-                display: 'Numerator'
-              }
-            ]
-          }
-        },
-        {
-          count: 1,
-          code: {
-            coding: [
-              {
-                system: '',
-                code: 'denominator-exclusion',
-                display: 'Denominator Exclusion'
-              }
-            ]
-          }
-        },
-        {
-          count: 0,
-          code: {
-            coding: [
-              {
-                system: '',
-                code: 'denominator',
-                display: 'Denominator'
-              }
-            ]
-          }
-        }
+      groupId: '',
+      statementResults: [],
+      populationResults: [
+        { populationType: Enums.PopulationType.IPP, criteriaExpression: 'Initial Population', result: true },
+        { populationType: Enums.PopulationType.DENOM, criteriaExpression: 'Denominator', result: false },
+        { populationType: Enums.PopulationType.DENEX, criteriaExpression: 'Denominator Exclusion', result: true },
+        { populationType: Enums.PopulationType.NUMER, criteriaExpression: 'Numerator', result: true }
       ]
     }
   ]
@@ -163,8 +113,11 @@ const MEASURE_BUNDLE_POPULATED = {
   selectedMeasureId: null
 };
 
-const MOCK_MEASURE_REPORT_LOOKUP: Record<string, MeasureReport> = {
-  'example-pt': MOCK_MEASURE_REPORT
+const MOCK_DETAILED_RESULT_LOOKUP: Record<
+  string,
+  CalculatorTypes.ExecutionResult<CalculatorTypes.DetailedPopulationGroupResult>
+> = {
+  'example-pt': MOCK_DETAILED_RESULT
 };
 
 const EXAMPLE_PATIENT: fhir4.Patient = {
@@ -187,7 +140,7 @@ describe('PopulationComparisonTable', () => {
     const MockMB = getMockRecoilState(measureBundleState, MEASURE_BUNDLE_POPULATED);
     const MockPatients = getMockRecoilState(patientTestCaseState, MOCK_TEST_CASE);
     const MockSelectedPatient = getMockRecoilState(selectedPatientState, 'example-pt');
-    const MockMeasureReportLookup = getMockRecoilState(measureReportLookupState, MOCK_MEASURE_REPORT_LOOKUP);
+    const MockDetailedResultLookup = getMockRecoilState(detailedResultLookupState, MOCK_DETAILED_RESULT_LOOKUP);
 
     await act(async () => {
       render(
@@ -196,7 +149,7 @@ describe('PopulationComparisonTable', () => {
             <MockMB />
             <MockPatients />
             <MockSelectedPatient />
-            <MockMeasureReportLookup />
+            <MockDetailedResultLookup />
             <Suspense>
               <PopulationComparisonTable patientId={'example-pt'} />
             </Suspense>

--- a/components/calculation/MeasureHighlightingPanel.tsx
+++ b/components/calculation/MeasureHighlightingPanel.tsx
@@ -1,8 +1,8 @@
 import { createStyles } from '@mantine/core';
 import { useRecoilValue } from 'recoil';
 import parse from 'html-react-parser';
-import { measureReportLookupState } from '../../state/atoms/measureReportLookup';
 import PopulationComparisonTable from './PopulationComparisonTable';
+import { detailedResultLookupState } from '../../state/atoms/detailedResultLookup';
 
 const useStyles = createStyles({
   highlightedMarkup: {
@@ -22,12 +22,14 @@ export interface MeasureHighlightingPanelProps {
 
 export default function MeasureHighlightingPanel({ patientId }: MeasureHighlightingPanelProps) {
   const { classes } = useStyles();
-  const measureReportLookup = useRecoilValue(measureReportLookupState);
+  const detailedResultLookup = useRecoilValue(detailedResultLookupState);
 
   return (
     <>
       <PopulationComparisonTable patientId={patientId} />
-      <div className={classes.highlightedMarkup}>{parse(measureReportLookup[patientId]?.text?.div || '')}</div>
+      <div className={classes.highlightedMarkup}>
+        {parse(detailedResultLookup[patientId]?.detailedResults?.[0].html || '')}
+      </div>
     </>
   );
 }

--- a/components/calculation/PopulationCalculation.tsx
+++ b/components/calculation/PopulationCalculation.tsx
@@ -13,10 +13,6 @@ import { createPatientBundle } from '../../util/fhir/resourceCreation';
 import PopulationResultTable, { LabeledDetailedResult } from './PopulationResultsTable';
 import { DetailedResult } from '../../util/types';
 
-interface PatientLabel {
-  [patientId: string]: string;
-}
-
 export default function PopulationCalculation() {
   const currentPatients = useRecoilValue(patientTestCaseState);
   const measureBundle = useRecoilValue(measureBundleState);
@@ -32,7 +28,7 @@ export default function PopulationCalculation() {
    * @returns { Object } mapping of patient ids to patient info labels
    */
   const createPatientLabels = () => {
-    const patientLabels: PatientLabel = {};
+    const patientLabels: Record<string, string> = {};
     Object.keys(currentPatients).forEach(id => {
       patientLabels[id] = getPatientInfoString(currentPatients[id].patient);
     });

--- a/components/calculation/PopulationCalculation.tsx
+++ b/components/calculation/PopulationCalculation.tsx
@@ -12,6 +12,7 @@ import { getPatientInfoString } from '../../util/fhir/patient';
 import { createPatientBundle } from '../../util/fhir/resourceCreation';
 import { DetailedDetailedResult } from './PopulationResultsTable';
 import PopulationResultTable from './PopulationResultsTable';
+import { DetailedResult } from '../../util/types';
 
 interface PatientLabel {
   [patientId: string]: string;
@@ -41,12 +42,10 @@ export default function PopulationCalculation() {
 
   /**
    * Uses fqm-execution library to perform calculation on all patients and return their
-   * measure reports.
-   * @returns { Array | void } array of measure reports (if measure bundle is provided)
+   * detailed results.
+   * @returns { Array | void } array of detailed results (if measure bundle is provided)
    */
-  const calculateDetailedResults = async (): Promise<
-    CalculatorTypes.ExecutionResult<CalculatorTypes.DetailedPopulationGroupResult>[] | void
-  > => {
+  const calculateDetailedResults = async (): Promise<DetailedResult[] | void> => {
     // specify options for calculation
     // TODO: revisit options after new fqm-execution release (calculateSDEs set to true throws error)
     const options: CalculatorTypes.CalculationOptions = {
@@ -71,14 +70,12 @@ export default function PopulationCalculation() {
         setClauseCoverageHTML(coverageHTML);
       }
       return results;
-      // const measureReports = MeasureReportBuilder.buildMeasureReports(measureBundle.content, results, options);
-      // return measureReports as fhir4.MeasureReport[];
     } else return;
   };
 
   /**
-   * Wrapper function that calls calculateMeasureReports() and creates the DetailedMeasureReport that will be used to render
-   * the population results. Catches errors in fqm-execution that result from calculateMeasureReports().
+   * Wrapper function that calls calculateDetailedResults() and creates the DetailedDetailedResult that will be used to render
+   * the population results. Catches errors in fqm-execution that result from calculateDetailedResults().
    */
   const runCalculation = () => {
     calculateDetailedResults()
@@ -90,7 +87,7 @@ export default function PopulationCalculation() {
             const patientId = dr.patientId;
             labeledDetailedResults.push({
               label: patientId ? patientLabels[patientId] : '',
-              detailedResult: dr as CalculatorTypes.ExecutionResult<CalculatorTypes.DetailedPopulationGroupResult>
+              detailedResult: dr as DetailedResult
             });
           });
           setDetailedResults(labeledDetailedResults);

--- a/components/calculation/PopulationCalculation.tsx
+++ b/components/calculation/PopulationCalculation.tsx
@@ -10,8 +10,7 @@ import { IconAlertCircle } from '@tabler/icons';
 import Link from 'next/link';
 import { getPatientInfoString } from '../../util/fhir/patient';
 import { createPatientBundle } from '../../util/fhir/resourceCreation';
-import { DetailedDetailedResult } from './PopulationResultsTable';
-import PopulationResultTable from './PopulationResultsTable';
+import PopulationResultTable, { LabeledDetailedResult } from './PopulationResultsTable';
 import { DetailedResult } from '../../util/types';
 
 interface PatientLabel {
@@ -22,7 +21,7 @@ export default function PopulationCalculation() {
   const currentPatients = useRecoilValue(patientTestCaseState);
   const measureBundle = useRecoilValue(measureBundleState);
   const measurementPeriod = useRecoilValue(measurementPeriodState);
-  const [detailedResults, setDetailedResults] = useState<DetailedDetailedResult[]>([]);
+  const [detailedResults, setDetailedResults] = useState<LabeledDetailedResult[]>([]);
   const [opened, setOpened] = useState(false);
   const [enableTableButton, setEnableTableButton] = useState(false);
   const [enableClauseCoverageButton, setEnableClauseCoverageButton] = useState(false);
@@ -74,7 +73,7 @@ export default function PopulationCalculation() {
   };
 
   /**
-   * Wrapper function that calls calculateDetailedResults() and creates the DetailedDetailedResult that will be used to render
+   * Wrapper function that calls calculateDetailedResults() and creates the LabeledDetailedResult that will be used to render
    * the population results. Catches errors in fqm-execution that result from calculateDetailedResults().
    */
   const runCalculation = () => {
@@ -82,7 +81,7 @@ export default function PopulationCalculation() {
       .then(detailedResults => {
         if (detailedResults) {
           const patientLabels = createPatientLabels();
-          const labeledDetailedResults: DetailedDetailedResult[] = [];
+          const labeledDetailedResults: LabeledDetailedResult[] = [];
           detailedResults.forEach(dr => {
             const patientId = dr.patientId;
             labeledDetailedResults.push({

--- a/components/calculation/PopulationResultsTable.tsx
+++ b/components/calculation/PopulationResultsTable.tsx
@@ -6,9 +6,9 @@ export type PopulationResultViewerProps = {
   results: DetailedResultInfoArray;
 };
 
-export type DetailedResultInfoArray = Array<DetailedDetailedResult>;
+export type DetailedResultInfoArray = Array<LabeledDetailedResult>;
 
-export declare type DetailedDetailedResult = {
+export type LabeledDetailedResult = {
   label: string;
   detailedResult: DetailedResult;
 };

--- a/components/calculation/PopulationResultsTable.tsx
+++ b/components/calculation/PopulationResultsTable.tsx
@@ -21,7 +21,7 @@ export type PopulationResult = {
 export default function PopulationResultTable({ results }: PopulationResultViewerProps) {
   const tableHeaders = useMemo(() => {
     return extractTableHeaders(results?.[0].detailedResult);
-  }, [results?.[0].detailedResult]);
+  }, [results]);
 
   function constructPopulationResultsArray(results: DetailedResultInfoArray) {
     return results
@@ -36,7 +36,7 @@ export default function PopulationResultTable({ results }: PopulationResultViewe
   ) {
     const group = dr.detailedResults?.[0];
     const populationResults = { label };
-    group?.populationResults?.reduce((acc: any, e) => {
+    group?.populationResults?.reduce((acc: PopulationResult, e) => {
       const key = e.criteriaExpression || e.populationType;
       if (key) {
         acc[key as string] = e.result === true ? 1 : 0;

--- a/components/calculation/PopulationResultsTable.tsx
+++ b/components/calculation/PopulationResultsTable.tsx
@@ -1,6 +1,6 @@
 import { Table } from '@mantine/core';
-import { CalculatorTypes } from 'fqm-execution';
 import { useMemo } from 'react';
+import { DetailedResult } from '../../util/types';
 
 export type PopulationResultViewerProps = {
   results: DetailedResultInfoArray;
@@ -10,12 +10,12 @@ export type DetailedResultInfoArray = Array<DetailedDetailedResult>;
 
 export declare type DetailedDetailedResult = {
   label: string;
-  detailedResult: CalculatorTypes.ExecutionResult<CalculatorTypes.DetailedPopulationGroupResult>;
+  detailedResult: DetailedResult;
 };
 
 export type PopulationResult = {
   label: string;
-  [key: string]: number | string | boolean;
+  [key: string]: number | string;
 };
 
 export default function PopulationResultTable({ results }: PopulationResultViewerProps) {
@@ -23,6 +23,9 @@ export default function PopulationResultTable({ results }: PopulationResultViewe
     return extractTableHeaders(results?.[0].detailedResult);
   }, [results]);
 
+  /**
+   * Converts an array of DetailedResults with labels and formats it into JSX table rows for display
+   */
   function constructPopulationResultsArray(results: DetailedResultInfoArray) {
     return results
       .filter(drInfo => drInfo.detailedResult)
@@ -30,10 +33,11 @@ export default function PopulationResultTable({ results }: PopulationResultViewe
         return extractPopulationResultRow(drInfo.detailedResult, drInfo.label);
       });
   }
-  function extractPopulationResultRow(
-    dr: CalculatorTypes.ExecutionResult<CalculatorTypes.DetailedPopulationGroupResult>,
-    label = 'Unlabeled Patient'
-  ) {
+
+  /**
+   * Strips population results off of a DetailedResult and calls PopulationResultsRow to format them into a TSX component
+   */
+  function extractPopulationResultRow(dr: DetailedResult, label = 'Unlabeled Patient') {
     const group = dr.detailedResults?.[0];
     const populationResults = { label };
     group?.populationResults?.reduce((acc: PopulationResult, e) => {
@@ -46,6 +50,9 @@ export default function PopulationResultTable({ results }: PopulationResultViewe
     return PopulationResultsRow(populationResults);
   }
 
+  /**
+   * Formats population results for a FHIR Patient into a TSX component for display as a table row
+   */
   function PopulationResultsRow(populationResult: PopulationResult) {
     return (
       <tr key={populationResult.label}>
@@ -57,9 +64,10 @@ export default function PopulationResultTable({ results }: PopulationResultViewe
     );
   }
 
-  function extractTableHeaders(
-    dr: CalculatorTypes.ExecutionResult<CalculatorTypes.DetailedPopulationGroupResult>
-  ): string[] {
+  /**
+   * Pulls off the population group criteria expression for use as table headers
+   */
+  function extractTableHeaders(dr: DetailedResult): string[] {
     const group = dr.detailedResults?.[0];
     if (group?.populationResults?.length) {
       return group?.populationResults.map(e => {

--- a/components/calculation/PopulationResultsTable.tsx
+++ b/components/calculation/PopulationResultsTable.tsx
@@ -1,0 +1,85 @@
+import { Table } from '@mantine/core';
+import { CalculatorTypes } from 'fqm-execution';
+import { useMemo } from 'react';
+
+export type PopulationResultViewerProps = {
+  results: DetailedResultInfoArray;
+};
+
+export type DetailedResultInfoArray = Array<DetailedDetailedResult>;
+
+export declare type DetailedDetailedResult = {
+  label: string;
+  detailedResult: CalculatorTypes.ExecutionResult<CalculatorTypes.DetailedPopulationGroupResult>;
+};
+
+export type PopulationResult = {
+  label: string;
+  [key: string]: number | string | boolean;
+};
+
+export default function PopulationResultTable({ results }: PopulationResultViewerProps) {
+  const tableHeaders = useMemo(() => {
+    return extractTableHeaders(results?.[0].detailedResult);
+  }, [results?.[0].detailedResult]);
+
+  function constructPopulationResultsArray(results: DetailedResultInfoArray) {
+    return results
+      .filter(drInfo => drInfo.detailedResult)
+      .map(drInfo => {
+        return extractPopulationResultRow(drInfo.detailedResult, drInfo.label);
+      });
+  }
+  function extractPopulationResultRow(
+    dr: CalculatorTypes.ExecutionResult<CalculatorTypes.DetailedPopulationGroupResult>,
+    label: string = 'Unlabeled Patient'
+  ) {
+    const group = dr.detailedResults?.[0];
+    const populationResults = { label };
+    group?.populationResults?.reduce((acc: any, e) => {
+      const key = e.criteriaExpression;
+      if (key) {
+        acc[key as string] = e.result === true ? 1 : 0;
+      }
+      return acc;
+    }, populationResults);
+    return PopulationResultsRow(populationResults);
+  }
+
+  function PopulationResultsRow(populationResult: PopulationResult) {
+    return (
+      <tr key={populationResult.label}>
+        <td>{populationResult.label}</td>
+        {tableHeaders.map(e => (
+          <td key={e}>{populationResult[e]}</td>
+        ))}
+      </tr>
+    );
+  }
+
+  function extractTableHeaders(
+    dr: CalculatorTypes.ExecutionResult<CalculatorTypes.DetailedPopulationGroupResult>
+  ): string[] {
+    const group = dr.detailedResults?.[0];
+    if (group?.populationResults?.length) {
+      return group?.populationResults.map(e => {
+        return e.criteriaExpression || '';
+      });
+    }
+    return [];
+  }
+
+  return (
+    <Table>
+      <thead>
+        <tr>
+          <th>Patient</th>
+          {tableHeaders?.map(e => (
+            <th key={e}>{e}</th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>{constructPopulationResultsArray(results)}</tbody>
+    </Table>
+  );
+}

--- a/components/calculation/PopulationResultsTable.tsx
+++ b/components/calculation/PopulationResultsTable.tsx
@@ -3,20 +3,15 @@ import { useMemo } from 'react';
 import { DetailedResult } from '../../util/types';
 
 export type PopulationResultViewerProps = {
-  results: DetailedResultInfoArray;
+  results: LabeledDetailedResult[];
 };
-
-export type DetailedResultInfoArray = Array<LabeledDetailedResult>;
 
 export type LabeledDetailedResult = {
   label: string;
   detailedResult: DetailedResult;
 };
 
-export type PopulationResult = {
-  label: string;
-  [key: string]: number | string;
-};
+export type PopulationResult = Record<string, string | number> & { label: string };
 
 export default function PopulationResultTable({ results }: PopulationResultViewerProps) {
   const tableHeaders = useMemo(() => {
@@ -24,9 +19,9 @@ export default function PopulationResultTable({ results }: PopulationResultViewe
   }, [results]);
 
   /**
-   * Converts an array of DetailedResults with labels and formats it into JSX table rows for display
+   * Converts an array of DetailedResults with labels into JSX table rows for display
    */
-  function constructPopulationResultsArray(results: DetailedResultInfoArray) {
+  function constructPopulationResultsArray(results: LabeledDetailedResult[]) {
     return results
       .filter(drInfo => drInfo.detailedResult)
       .map(drInfo => {
@@ -39,15 +34,15 @@ export default function PopulationResultTable({ results }: PopulationResultViewe
    */
   function extractPopulationResultRow(dr: DetailedResult, label = 'Unlabeled Patient') {
     const group = dr.detailedResults?.[0];
-    const populationResults = { label };
+    const labeledPopulationResults = { label };
     group?.populationResults?.reduce((acc: PopulationResult, e) => {
       const key = e.criteriaExpression || e.populationType;
       if (key) {
         acc[key as string] = e.result === true ? 1 : 0;
       }
       return acc;
-    }, populationResults);
-    return PopulationResultsRow(populationResults);
+    }, labeledPopulationResults);
+    return PopulationResultsRow(labeledPopulationResults);
   }
 
   /**

--- a/components/calculation/PopulationResultsTable.tsx
+++ b/components/calculation/PopulationResultsTable.tsx
@@ -32,12 +32,12 @@ export default function PopulationResultTable({ results }: PopulationResultViewe
   }
   function extractPopulationResultRow(
     dr: CalculatorTypes.ExecutionResult<CalculatorTypes.DetailedPopulationGroupResult>,
-    label: string = 'Unlabeled Patient'
+    label = 'Unlabeled Patient'
   ) {
     const group = dr.detailedResults?.[0];
     const populationResults = { label };
     group?.populationResults?.reduce((acc: any, e) => {
-      const key = e.criteriaExpression;
+      const key = e.criteriaExpression || e.populationType;
       if (key) {
         acc[key as string] = e.result === true ? 1 : 0;
       }

--- a/components/resource-creation/ResourcePanel.tsx
+++ b/components/resource-creation/ResourcePanel.tsx
@@ -11,12 +11,13 @@ import CodeEditorModal from '../modals/CodeEditorModal';
 import ResourceDisplay from './ResourceDisplay';
 import ResourceSelection from './ResourceSelection';
 import { showNotification } from '@mantine/notifications';
-import { calculateMeasureReport } from '../../util/MeasureCalculation';
 import { calculationLoading } from '../../state/atoms/calculationLoading';
 import { measureBundleState } from '../../state/atoms/measureBundle';
 import { measurementPeriodState } from '../../state/atoms/measurementPeriod';
-import { measureReportLookupState } from '../../state/atoms/measureReportLookup';
 import { getPatientNameString } from '../../util/fhir/patient';
+import { detailedResultLookupState } from '../../state/atoms/detailedResultLookup';
+import { Calculator, CalculatorTypes } from 'fqm-execution';
+import { createPatientBundle } from '../../util/fhir/resourceCreation';
 
 export default function ResourcePanel() {
   const selectedPatient = useRecoilValue(selectedPatientState);
@@ -25,7 +26,7 @@ export default function ResourcePanel() {
   const setIsCalculationLoading = useSetRecoilState(calculationLoading);
   const measureBundle = useRecoilValue(measureBundleState);
   const measurementPeriod = useRecoilValue(measurementPeriodState);
-  const [measureReportLookup, setMeasureReportLookup] = useRecoilState(measureReportLookupState);
+  const [detailedResultLookup, setDetailedResultLookup] = useRecoilState(detailedResultLookupState);
 
   const createNewResource = (val: string) => {
     // TODO: Validate the incoming JSON as FHIR
@@ -52,15 +53,19 @@ export default function ResourcePanel() {
         setIsCalculationLoading(true);
 
         setTimeout(() => {
-          produce(measureReportLookup, async draftState => {
+          produce(detailedResultLookup, async draftState => {
             if (measureBundle.content) {
+              const options: CalculatorTypes.CalculationOptions = {
+                measurementPeriodStart: measurementPeriod.start?.toISOString(),
+                measurementPeriodEnd: measurementPeriod.end?.toISOString()
+              };
               try {
-                draftState[selectedPatient] = await calculateMeasureReport(
-                  nextResourceState[selectedPatient],
-                  measureBundle.content,
-                  measurementPeriod.start?.toISOString(),
-                  measurementPeriod.end?.toISOString()
+                const patientBundle = createPatientBundle(
+                  nextResourceState[selectedPatient].patient,
+                  nextResourceState[selectedPatient].resources
                 );
+                const { results } = await Calculator.calculate(measureBundle.content, [patientBundle], options);
+                draftState[selectedPatient] = results[0];
               } catch (error) {
                 if (error instanceof Error) {
                   showNotification({
@@ -72,8 +77,8 @@ export default function ResourcePanel() {
                 }
               }
             }
-          }).then(nextMRLookupState => {
-            setMeasureReportLookup(nextMRLookupState);
+          }).then(nextDRLookupState => {
+            setDetailedResultLookup(nextDRLookupState);
             setIsCalculationLoading(false);
           });
         }, 400);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,11 @@
       "dependencies": {
         "@codemirror/lang-json": "^0.20.0",
         "@codemirror/lint": "^0.20.3",
+        "@emotion/cache": "^11.10.7",
         "@emotion/react": "^11.10.0",
+        "@emotion/serialize": "^1.1.1",
         "@emotion/server": "^11.10.0",
+        "@emotion/utils": "^1.2.0",
         "@fhir-typescript/r4-core": "0.0.12-beta.15",
         "@mantine/core": "^5.3.1",
         "@mantine/dates": "^5.3.1",
@@ -817,38 +820,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@emotion/babel-plugin/node_modules/@emotion/hash": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.0.tgz",
-      "integrity": "sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ=="
-    },
-    "node_modules/@emotion/babel-plugin/node_modules/@emotion/memoize": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
-      "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
-    },
-    "node_modules/@emotion/babel-plugin/node_modules/@emotion/serialize": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.0.tgz",
-      "integrity": "sha512-F1ZZZW51T/fx+wKbVlwsfchr5q97iW8brAnXmsskz4d0hVB4O3M/SiA3SaeH06x02lSNzkkQv+n3AX3kCXKSFA==",
-      "dependencies": {
-        "@emotion/hash": "^0.9.0",
-        "@emotion/memoize": "^0.8.0",
-        "@emotion/unitless": "^0.8.0",
-        "@emotion/utils": "^1.2.0",
-        "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@emotion/babel-plugin/node_modules/@emotion/unitless": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.0.tgz",
-      "integrity": "sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw=="
-    },
-    "node_modules/@emotion/babel-plugin/node_modules/@emotion/utils": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.0.tgz",
-      "integrity": "sha512-sn3WH53Kzpw8oQ5mgMmIzzyAaH2ZqFEbozVVBSYp538E06OSE6ytOp7pRAjNQR+Q/orwqdQYJSe2m3hCOeznkw=="
-    },
     "node_modules/@emotion/babel-plugin/node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -856,6 +827,33 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/@emotion/cache": {
+      "version": "11.10.7",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.7.tgz",
+      "integrity": "sha512-VLl1/2D6LOjH57Y8Vem1RoZ9haWF4jesHDGiHtKozDQuBIkJm2gimVo0I02sWCuzZtVACeixTVB4jeE8qvCBoQ==",
+      "dependencies": {
+        "@emotion/memoize": "^0.8.0",
+        "@emotion/sheet": "^1.2.1",
+        "@emotion/utils": "^1.2.0",
+        "@emotion/weak-memoize": "^0.3.0",
+        "stylis": "4.1.3"
+      }
+    },
+    "node_modules/@emotion/cache/node_modules/stylis": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.1.3.tgz",
+      "integrity": "sha512-GP6WDNWf+o403jrEp9c5jibKavrtLW+/qYGhFxFrG8maXhwTBI7gLLhiBb0o7uFccWN+EOS9aMO6cGHWAO07OA=="
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.0.tgz",
+      "integrity": "sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ=="
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
+      "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
     },
     "node_modules/@emotion/react": {
       "version": "11.10.4",
@@ -895,32 +893,10 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@emotion/react/node_modules/@emotion/cache": {
-      "version": "11.10.3",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.3.tgz",
-      "integrity": "sha512-Psmp/7ovAa8appWh3g51goxu/z3iVms7JXOreq136D8Bbn6dYraPnmL6mdM8GThEx9vwSn92Fz+mGSjBzN8UPQ==",
-      "dependencies": {
-        "@emotion/memoize": "^0.8.0",
-        "@emotion/sheet": "^1.2.0",
-        "@emotion/utils": "^1.2.0",
-        "@emotion/weak-memoize": "^0.3.0",
-        "stylis": "4.0.13"
-      }
-    },
-    "node_modules/@emotion/react/node_modules/@emotion/hash": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.0.tgz",
-      "integrity": "sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ=="
-    },
-    "node_modules/@emotion/react/node_modules/@emotion/memoize": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
-      "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
-    },
-    "node_modules/@emotion/react/node_modules/@emotion/serialize": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.0.tgz",
-      "integrity": "sha512-F1ZZZW51T/fx+wKbVlwsfchr5q97iW8brAnXmsskz4d0hVB4O3M/SiA3SaeH06x02lSNzkkQv+n3AX3kCXKSFA==",
+    "node_modules/@emotion/serialize": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.1.tgz",
+      "integrity": "sha512-Zl/0LFggN7+L1liljxXdsVSVlg6E/Z/olVWpfxUTxOAmi8NU7YoeWeLfi1RmnB2TATHoaWwIBRoL+FvAJiTUQA==",
       "dependencies": {
         "@emotion/hash": "^0.9.0",
         "@emotion/memoize": "^0.8.0",
@@ -928,26 +904,6 @@
         "@emotion/utils": "^1.2.0",
         "csstype": "^3.0.2"
       }
-    },
-    "node_modules/@emotion/react/node_modules/@emotion/sheet": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.0.tgz",
-      "integrity": "sha512-OiTkRgpxescko+M51tZsMq7Puu/KP55wMT8BgpcXVG2hqXc0Vo0mfymJ/Uj24Hp0i083ji/o0aLddh08UEjq8w=="
-    },
-    "node_modules/@emotion/react/node_modules/@emotion/unitless": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.0.tgz",
-      "integrity": "sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw=="
-    },
-    "node_modules/@emotion/react/node_modules/@emotion/utils": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.0.tgz",
-      "integrity": "sha512-sn3WH53Kzpw8oQ5mgMmIzzyAaH2ZqFEbozVVBSYp538E06OSE6ytOp7pRAjNQR+Q/orwqdQYJSe2m3hCOeznkw=="
-    },
-    "node_modules/@emotion/react/node_modules/@emotion/weak-memoize": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.0.tgz",
-      "integrity": "sha512-AHPmaAx+RYfZz0eYu6Gviiagpmiyw98ySSlQvCUhVGDRtDFe4DBS0x1bSjdF3gqUDYOczB+yYvBTtEylYSdRhg=="
     },
     "node_modules/@emotion/server": {
       "version": "11.10.0",
@@ -968,10 +924,15 @@
         }
       }
     },
-    "node_modules/@emotion/server/node_modules/@emotion/utils": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.0.tgz",
-      "integrity": "sha512-sn3WH53Kzpw8oQ5mgMmIzzyAaH2ZqFEbozVVBSYp538E06OSE6ytOp7pRAjNQR+Q/orwqdQYJSe2m3hCOeznkw=="
+    "node_modules/@emotion/sheet": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.1.tgz",
+      "integrity": "sha512-zxRBwl93sHMsOj4zs+OslQKg/uhF38MB+OMKoCrVuS0nyTkqnau+BM3WGEoOptg9Oz45T/aIGs1qbVAsEFo3nA=="
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.0.tgz",
+      "integrity": "sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw=="
     },
     "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
       "version": "1.0.0",
@@ -980,6 +941,16 @@
       "peerDependencies": {
         "react": ">=16.8.0"
       }
+    },
+    "node_modules/@emotion/utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.0.tgz",
+      "integrity": "sha512-sn3WH53Kzpw8oQ5mgMmIzzyAaH2ZqFEbozVVBSYp538E06OSE6ytOp7pRAjNQR+Q/orwqdQYJSe2m3hCOeznkw=="
+    },
+    "node_modules/@emotion/weak-memoize": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.0.tgz",
+      "integrity": "sha512-AHPmaAx+RYfZz0eYu6Gviiagpmiyw98ySSlQvCUhVGDRtDFe4DBS0x1bSjdF3gqUDYOczB+yYvBTtEylYSdRhg=="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.2.3",
@@ -9371,44 +9342,41 @@
             "regenerator-runtime": "^0.13.4"
           }
         },
-        "@emotion/hash": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.0.tgz",
-          "integrity": "sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ=="
-        },
-        "@emotion/memoize": {
-          "version": "0.8.0",
-          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
-          "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
-        },
-        "@emotion/serialize": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.0.tgz",
-          "integrity": "sha512-F1ZZZW51T/fx+wKbVlwsfchr5q97iW8brAnXmsskz4d0hVB4O3M/SiA3SaeH06x02lSNzkkQv+n3AX3kCXKSFA==",
-          "requires": {
-            "@emotion/hash": "^0.9.0",
-            "@emotion/memoize": "^0.8.0",
-            "@emotion/unitless": "^0.8.0",
-            "@emotion/utils": "^1.2.0",
-            "csstype": "^3.0.2"
-          }
-        },
-        "@emotion/unitless": {
-          "version": "0.8.0",
-          "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.0.tgz",
-          "integrity": "sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw=="
-        },
-        "@emotion/utils": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.0.tgz",
-          "integrity": "sha512-sn3WH53Kzpw8oQ5mgMmIzzyAaH2ZqFEbozVVBSYp538E06OSE6ytOp7pRAjNQR+Q/orwqdQYJSe2m3hCOeznkw=="
-        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="
         }
       }
+    },
+    "@emotion/cache": {
+      "version": "11.10.7",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.7.tgz",
+      "integrity": "sha512-VLl1/2D6LOjH57Y8Vem1RoZ9haWF4jesHDGiHtKozDQuBIkJm2gimVo0I02sWCuzZtVACeixTVB4jeE8qvCBoQ==",
+      "requires": {
+        "@emotion/memoize": "^0.8.0",
+        "@emotion/sheet": "^1.2.1",
+        "@emotion/utils": "^1.2.0",
+        "@emotion/weak-memoize": "^0.3.0",
+        "stylis": "4.1.3"
+      },
+      "dependencies": {
+        "stylis": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.1.3.tgz",
+          "integrity": "sha512-GP6WDNWf+o403jrEp9c5jibKavrtLW+/qYGhFxFrG8maXhwTBI7gLLhiBb0o7uFccWN+EOS9aMO6cGHWAO07OA=="
+        }
+      }
+    },
+    "@emotion/hash": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.0.tgz",
+      "integrity": "sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ=="
+    },
+    "@emotion/memoize": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
+      "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
     },
     "@emotion/react": {
       "version": "11.10.4",
@@ -9432,61 +9400,19 @@
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
-        },
-        "@emotion/cache": {
-          "version": "11.10.3",
-          "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.3.tgz",
-          "integrity": "sha512-Psmp/7ovAa8appWh3g51goxu/z3iVms7JXOreq136D8Bbn6dYraPnmL6mdM8GThEx9vwSn92Fz+mGSjBzN8UPQ==",
-          "requires": {
-            "@emotion/memoize": "^0.8.0",
-            "@emotion/sheet": "^1.2.0",
-            "@emotion/utils": "^1.2.0",
-            "@emotion/weak-memoize": "^0.3.0",
-            "stylis": "4.0.13"
-          }
-        },
-        "@emotion/hash": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.0.tgz",
-          "integrity": "sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ=="
-        },
-        "@emotion/memoize": {
-          "version": "0.8.0",
-          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
-          "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
-        },
-        "@emotion/serialize": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.0.tgz",
-          "integrity": "sha512-F1ZZZW51T/fx+wKbVlwsfchr5q97iW8brAnXmsskz4d0hVB4O3M/SiA3SaeH06x02lSNzkkQv+n3AX3kCXKSFA==",
-          "requires": {
-            "@emotion/hash": "^0.9.0",
-            "@emotion/memoize": "^0.8.0",
-            "@emotion/unitless": "^0.8.0",
-            "@emotion/utils": "^1.2.0",
-            "csstype": "^3.0.2"
-          }
-        },
-        "@emotion/sheet": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.0.tgz",
-          "integrity": "sha512-OiTkRgpxescko+M51tZsMq7Puu/KP55wMT8BgpcXVG2hqXc0Vo0mfymJ/Uj24Hp0i083ji/o0aLddh08UEjq8w=="
-        },
-        "@emotion/unitless": {
-          "version": "0.8.0",
-          "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.0.tgz",
-          "integrity": "sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw=="
-        },
-        "@emotion/utils": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.0.tgz",
-          "integrity": "sha512-sn3WH53Kzpw8oQ5mgMmIzzyAaH2ZqFEbozVVBSYp538E06OSE6ytOp7pRAjNQR+Q/orwqdQYJSe2m3hCOeznkw=="
-        },
-        "@emotion/weak-memoize": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.0.tgz",
-          "integrity": "sha512-AHPmaAx+RYfZz0eYu6Gviiagpmiyw98ySSlQvCUhVGDRtDFe4DBS0x1bSjdF3gqUDYOczB+yYvBTtEylYSdRhg=="
         }
+      }
+    },
+    "@emotion/serialize": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.1.tgz",
+      "integrity": "sha512-Zl/0LFggN7+L1liljxXdsVSVlg6E/Z/olVWpfxUTxOAmi8NU7YoeWeLfi1RmnB2TATHoaWwIBRoL+FvAJiTUQA==",
+      "requires": {
+        "@emotion/hash": "^0.9.0",
+        "@emotion/memoize": "^0.8.0",
+        "@emotion/unitless": "^0.8.0",
+        "@emotion/utils": "^1.2.0",
+        "csstype": "^3.0.2"
       }
     },
     "@emotion/server": {
@@ -9498,20 +9424,33 @@
         "html-tokenize": "^2.0.0",
         "multipipe": "^1.0.2",
         "through": "^2.3.8"
-      },
-      "dependencies": {
-        "@emotion/utils": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.0.tgz",
-          "integrity": "sha512-sn3WH53Kzpw8oQ5mgMmIzzyAaH2ZqFEbozVVBSYp538E06OSE6ytOp7pRAjNQR+Q/orwqdQYJSe2m3hCOeznkw=="
-        }
       }
+    },
+    "@emotion/sheet": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.1.tgz",
+      "integrity": "sha512-zxRBwl93sHMsOj4zs+OslQKg/uhF38MB+OMKoCrVuS0nyTkqnau+BM3WGEoOptg9Oz45T/aIGs1qbVAsEFo3nA=="
+    },
+    "@emotion/unitless": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.0.tgz",
+      "integrity": "sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw=="
     },
     "@emotion/use-insertion-effect-with-fallbacks": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.0.tgz",
       "integrity": "sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A==",
       "requires": {}
+    },
+    "@emotion/utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.0.tgz",
+      "integrity": "sha512-sn3WH53Kzpw8oQ5mgMmIzzyAaH2ZqFEbozVVBSYp538E06OSE6ytOp7pRAjNQR+Q/orwqdQYJSe2m3hCOeznkw=="
+    },
+    "@emotion/weak-memoize": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.0.tgz",
+      "integrity": "sha512-AHPmaAx+RYfZz0eYu6Gviiagpmiyw98ySSlQvCUhVGDRtDFe4DBS0x1bSjdF3gqUDYOczB+yYvBTtEylYSdRhg=="
     },
     "@eslint/eslintrc": {
       "version": "1.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "@tabler/icons": "^1.105.0",
         "@uiw/react-codemirror": "^4.7.0",
         "dayjs": "^1.11.2",
-        "ecqm-visualizers": "0.0.1",
         "fhirpath": "^2.14.6",
         "file-saver": "^2.0.5",
         "fqm-execution": "git+https://git@github.com/projecttacoma/fqm-execution",
@@ -858,28 +857,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/@emotion/cache": {
-      "version": "11.7.1",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.7.1.tgz",
-      "integrity": "sha512-r65Zy4Iljb8oyjtLeCuBH8Qjiy107dOYC6SJq7g7GV5UCQWMObY4SJDPGFjiiVpPrOJ2hmJOoBiYTC7hwx9E2A==",
-      "dependencies": {
-        "@emotion/memoize": "^0.7.4",
-        "@emotion/sheet": "^1.1.0",
-        "@emotion/utils": "^1.0.0",
-        "@emotion/weak-memoize": "^0.2.5",
-        "stylis": "4.0.13"
-      }
-    },
-    "node_modules/@emotion/hash": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
-      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
-    },
-    "node_modules/@emotion/memoize": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.5.tgz",
-      "integrity": "sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ=="
-    },
     "node_modules/@emotion/react": {
       "version": "11.10.4",
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.10.4.tgz",
@@ -972,18 +949,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.0.tgz",
       "integrity": "sha512-AHPmaAx+RYfZz0eYu6Gviiagpmiyw98ySSlQvCUhVGDRtDFe4DBS0x1bSjdF3gqUDYOczB+yYvBTtEylYSdRhg=="
     },
-    "node_modules/@emotion/serialize": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.0.2.tgz",
-      "integrity": "sha512-95MgNJ9+/ajxU7QIAruiOAdYNjxZX7G2mhgrtDWswA21VviYIRP1R5QilZ/bDY42xiKsaktP4egJb3QdYQZi1A==",
-      "dependencies": {
-        "@emotion/hash": "^0.8.0",
-        "@emotion/memoize": "^0.7.4",
-        "@emotion/unitless": "^0.7.5",
-        "@emotion/utils": "^1.0.0",
-        "csstype": "^3.0.2"
-      }
-    },
     "node_modules/@emotion/server": {
       "version": "11.10.0",
       "resolved": "https://registry.npmjs.org/@emotion/server/-/server-11.10.0.tgz",
@@ -1008,16 +973,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.0.tgz",
       "integrity": "sha512-sn3WH53Kzpw8oQ5mgMmIzzyAaH2ZqFEbozVVBSYp538E06OSE6ytOp7pRAjNQR+Q/orwqdQYJSe2m3hCOeznkw=="
     },
-    "node_modules/@emotion/sheet": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.1.0.tgz",
-      "integrity": "sha512-u0AX4aSo25sMAygCuQTzS+HsImZFuS8llY8O7b9MDRzbJM0kVJlAz6KNDqcG7pOuQZJmj/8X/rAW+66kMnMW+g=="
-    },
-    "node_modules/@emotion/unitless": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
-      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
-    },
     "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.0.tgz",
@@ -1025,16 +980,6 @@
       "peerDependencies": {
         "react": ">=16.8.0"
       }
-    },
-    "node_modules/@emotion/utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.0.0.tgz",
-      "integrity": "sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA=="
-    },
-    "node_modules/@emotion/weak-memoize": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
-      "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.2.3",
@@ -2148,53 +2093,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@popperjs/core": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
-      "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
-      }
-    },
-    "node_modules/@radix-ui/number": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-0.1.0.tgz",
-      "integrity": "sha512-rpf6QiOWLHAkM4FEMYu9i+5Jr8cKT893+R4mPpcdsy4LD7omr9JfdOqj/h/xPA5+EcVrpMMlU6rrRYpUB5UI8g==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10"
-      }
-    },
-    "node_modules/@radix-ui/primitive": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-0.1.0.tgz",
-      "integrity": "sha512-tqxZKybwN5Fa3VzZry4G6mXAAb9aAqKmPtnVbZpL0vsBwvOHTBwsjHVPXylocYLwEtBY9SCe665bYnNB515uoA==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10"
-      }
-    },
-    "node_modules/@radix-ui/react-compose-refs": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-0.1.0.tgz",
-      "integrity": "sha512-eyclbh+b77k+69Dk72q3694OHrn9B3QsoIRx7ywX341U9RK1ThgQjMFZoPtmZNQTksXHLNEiefR8hGVeFyInGg==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@radix-ui/react-context": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-0.1.1.tgz",
-      "integrity": "sha512-PkyVX1JsLBioeu0jB9WvRpDBBLtLZohVDT3BB5CTSJqActma8S8030P57mWZb4baZifMvN7KKWPAA40UmWKkQg==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
     "node_modules/@radix-ui/react-direction": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.0.0.tgz",
@@ -2204,96 +2102,6 @@
       },
       "peerDependencies": {
         "react": "^16.8 || ^17.0 || ^18.0"
-      }
-    },
-    "node_modules/@radix-ui/react-presence": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-0.1.2.tgz",
-      "integrity": "sha512-3BRlFZraooIUfRlyN+b/Xs5hq1lanOOo/+3h6Pwu2GMFjkGKKa4Rd51fcqGqnVlbr3jYg+WLuGyAV4KlgqwrQw==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-compose-refs": "0.1.0",
-        "@radix-ui/react-use-layout-effect": "0.1.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8"
-      }
-    },
-    "node_modules/@radix-ui/react-primitive": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-0.1.4.tgz",
-      "integrity": "sha512-6gSl2IidySupIMJFjYnDIkIWRyQdbu/AHK7rbICPani+LW4b0XdxBXc46og/iZvuwW8pjCS8I2SadIerv84xYA==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-slot": "0.1.2"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@radix-ui/react-scroll-area": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-0.1.4.tgz",
-      "integrity": "sha512-QHxRsjy+hsHwQYJ9cCNgSJ5+6ioZu1KhwD1UOXoHNciuFGMX08v+uJPKXIz+ySv03Rx6cOz6f/Fk5aPHRMFi/A==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/number": "0.1.0",
-        "@radix-ui/primitive": "0.1.0",
-        "@radix-ui/react-compose-refs": "0.1.0",
-        "@radix-ui/react-context": "0.1.1",
-        "@radix-ui/react-presence": "0.1.2",
-        "@radix-ui/react-primitive": "0.1.4",
-        "@radix-ui/react-use-callback-ref": "0.1.0",
-        "@radix-ui/react-use-direction": "0.1.0",
-        "@radix-ui/react-use-layout-effect": "0.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@radix-ui/react-slot": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-0.1.2.tgz",
-      "integrity": "sha512-ADkqfL+agEzEguU3yS26jfB50hRrwf7U4VTwAOZEmi/g+ITcBWe12yM46ueS/UCIMI9Py+gFUaAdxgxafFvY2Q==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-compose-refs": "0.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@radix-ui/react-use-callback-ref": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-0.1.0.tgz",
-      "integrity": "sha512-Va041McOFFl+aV+sejvl0BS2aeHx86ND9X/rVFmEFQKTXCp6xgUK0NGUAGcgBlIjnJSbMYPGEk1xKSSlVcN2Aw==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@radix-ui/react-use-direction": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-direction/-/react-use-direction-0.1.0.tgz",
-      "integrity": "sha512-NajpY/An9TCPSfOVkgWIdXJV+VuWl67PxB6kOKYmtNAFHvObzIoh8o0n9sAuwSAyFCZVq211FEf9gvVDRhOyiA==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@radix-ui/react-use-layout-effect": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-0.1.0.tgz",
-      "integrity": "sha512-+wdeS51Y+E1q1Wmd+1xSSbesZkpVj4jsg0BojCbopWvgq5iBvixw5vgemscdh58ep98BwUbsFYnrywFhV9yrVg==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
       }
     },
     "node_modules/@rushstack/eslint-patch": {
@@ -4159,95 +3967,6 @@
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
-    },
-    "node_modules/ecqm-visualizers": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/ecqm-visualizers/-/ecqm-visualizers-0.0.1.tgz",
-      "integrity": "sha512-Ap+c/0c5E4isrPBd1Jfa5fzwDROqD6jRyFu4QkOPdn0BSxIlXFuVr2+af8N4KBf1w4UHZL0V+jIAkXfeml6NBw==",
-      "dependencies": {
-        "@fhir-typescript/r4-core": "0.0.12-beta.15",
-        "@mantine/core": "^4.2.12",
-        "@mantine/hooks": "^4.2.12"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": ">=16"
-      }
-    },
-    "node_modules/ecqm-visualizers/node_modules/@mantine/core": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@mantine/core/-/core-4.2.12.tgz",
-      "integrity": "sha512-PZcVUvcSZiZmLR1moKBJFdFIh6a4C+TE2ao91kzTAlH5Qb8t/V3ONbfPk3swHoYr7OSLJQM8vZ7UD5sFDiq0/g==",
-      "dependencies": {
-        "@mantine/styles": "4.2.12",
-        "@popperjs/core": "^2.9.3",
-        "@radix-ui/react-scroll-area": "^0.1.1",
-        "react-popper": "^2.2.5",
-        "react-textarea-autosize": "^8.3.2"
-      },
-      "peerDependencies": {
-        "@mantine/hooks": "4.2.12",
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/ecqm-visualizers/node_modules/@mantine/hooks": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-4.2.12.tgz",
-      "integrity": "sha512-/2GOsgv1tAUFBXOUV0YBZdDZHj3pHN82Sv1oI/hJMjfIT3ZkGeeiJO8Cw9cBcn76t6caP6Czi3hcuKhjz71O+A==",
-      "peerDependencies": {
-        "react": ">=16.8.0"
-      }
-    },
-    "node_modules/ecqm-visualizers/node_modules/@mantine/styles": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@mantine/styles/-/styles-4.2.12.tgz",
-      "integrity": "sha512-9q1DzW0UNW/ORMGLHfN2XABOSEm0ZQebhNlLD757R6OQouoLuUf9elUwgGOXSyogMlsAYoy84XbJ3ZbbTm4YCA==",
-      "dependencies": {
-        "@emotion/cache": "11.7.1",
-        "@emotion/react": "11.7.1",
-        "@emotion/serialize": "1.0.2",
-        "@emotion/utils": "1.0.0",
-        "clsx": "^1.1.1",
-        "csstype": "3.0.9"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/ecqm-visualizers/node_modules/@mantine/styles/node_modules/@emotion/react": {
-      "version": "11.7.1",
-      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.7.1.tgz",
-      "integrity": "sha512-DV2Xe3yhkF1yT4uAUoJcYL1AmrnO5SVsdfvu+fBuS7IbByDeTVx9+wFmvx9Idzv7/78+9Mgx2Hcmr7Fex3tIyw==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@emotion/cache": "^11.7.1",
-        "@emotion/serialize": "^1.0.2",
-        "@emotion/sheet": "^1.1.0",
-        "@emotion/utils": "^1.0.0",
-        "@emotion/weak-memoize": "^0.2.5",
-        "hoist-non-react-statics": "^3.3.1"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0",
-        "react": ">=16.8.0"
-      },
-      "peerDependenciesMeta": {
-        "@babel/core": {
-          "optional": true
-        },
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ecqm-visualizers/node_modules/csstype": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.9.tgz",
-      "integrity": "sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw=="
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.137",
@@ -7719,50 +7438,15 @@
         "react": ">= 16.8 || 18.0.0"
       }
     },
-    "node_modules/react-fast-compare": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
-      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
-    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
-    "node_modules/react-popper": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
-      "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
-      "dependencies": {
-        "react-fast-compare": "^3.0.1",
-        "warning": "^4.0.2"
-      },
-      "peerDependencies": {
-        "@popperjs/core": "^2.0.0",
-        "react": "^16.8.0 || ^17 || ^18",
-        "react-dom": "^16.8.0 || ^17 || ^18"
-      }
-    },
     "node_modules/react-property": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.0.tgz",
       "integrity": "sha512-kzmNjIgU32mO4mmH5+iUyrqlpFQhF8K2k7eZ4fdLSOPFrD1XgEuSBv9LDEgxRXTMBqMd8ppT0x6TIzqE5pdGdw=="
-    },
-    "node_modules/react-textarea-autosize": {
-      "version": "8.3.3",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.3.tgz",
-      "integrity": "sha512-2XlHXK2TDxS6vbQaoPbMOfQ8GK7+irc2fVK6QFIcC8GOnH3zI/v481n+j1L0WaPVvKxwesnY93fEfH++sus2rQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.10.2",
-        "use-composed-ref": "^1.0.0",
-        "use-latest": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0"
-      }
     },
     "node_modules/react-transition-group": {
       "version": "4.4.2",
@@ -8826,14 +8510,6 @@
         "makeerror": "1.0.12"
       }
     },
-    "node_modules/warning": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
-      }
-    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -9734,28 +9410,6 @@
         }
       }
     },
-    "@emotion/cache": {
-      "version": "11.7.1",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.7.1.tgz",
-      "integrity": "sha512-r65Zy4Iljb8oyjtLeCuBH8Qjiy107dOYC6SJq7g7GV5UCQWMObY4SJDPGFjiiVpPrOJ2hmJOoBiYTC7hwx9E2A==",
-      "requires": {
-        "@emotion/memoize": "^0.7.4",
-        "@emotion/sheet": "^1.1.0",
-        "@emotion/utils": "^1.0.0",
-        "@emotion/weak-memoize": "^0.2.5",
-        "stylis": "4.0.13"
-      }
-    },
-    "@emotion/hash": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
-      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
-    },
-    "@emotion/memoize": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.5.tgz",
-      "integrity": "sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ=="
-    },
     "@emotion/react": {
       "version": "11.10.4",
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.10.4.tgz",
@@ -9835,18 +9489,6 @@
         }
       }
     },
-    "@emotion/serialize": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.0.2.tgz",
-      "integrity": "sha512-95MgNJ9+/ajxU7QIAruiOAdYNjxZX7G2mhgrtDWswA21VviYIRP1R5QilZ/bDY42xiKsaktP4egJb3QdYQZi1A==",
-      "requires": {
-        "@emotion/hash": "^0.8.0",
-        "@emotion/memoize": "^0.7.4",
-        "@emotion/unitless": "^0.7.5",
-        "@emotion/utils": "^1.0.0",
-        "csstype": "^3.0.2"
-      }
-    },
     "@emotion/server": {
       "version": "11.10.0",
       "resolved": "https://registry.npmjs.org/@emotion/server/-/server-11.10.0.tgz",
@@ -9865,31 +9507,11 @@
         }
       }
     },
-    "@emotion/sheet": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.1.0.tgz",
-      "integrity": "sha512-u0AX4aSo25sMAygCuQTzS+HsImZFuS8llY8O7b9MDRzbJM0kVJlAz6KNDqcG7pOuQZJmj/8X/rAW+66kMnMW+g=="
-    },
-    "@emotion/unitless": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
-      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
-    },
     "@emotion/use-insertion-effect-with-fallbacks": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.0.tgz",
       "integrity": "sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A==",
       "requires": {}
-    },
-    "@emotion/utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.0.0.tgz",
-      "integrity": "sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA=="
-    },
-    "@emotion/weak-memoize": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
-      "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
     "@eslint/eslintrc": {
       "version": "1.2.3",
@@ -10688,116 +10310,10 @@
         "fastq": "^1.6.0"
       }
     },
-    "@popperjs/core": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
-      "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw=="
-    },
-    "@radix-ui/number": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-0.1.0.tgz",
-      "integrity": "sha512-rpf6QiOWLHAkM4FEMYu9i+5Jr8cKT893+R4mPpcdsy4LD7omr9JfdOqj/h/xPA5+EcVrpMMlU6rrRYpUB5UI8g==",
-      "requires": {
-        "@babel/runtime": "^7.13.10"
-      }
-    },
-    "@radix-ui/primitive": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-0.1.0.tgz",
-      "integrity": "sha512-tqxZKybwN5Fa3VzZry4G6mXAAb9aAqKmPtnVbZpL0vsBwvOHTBwsjHVPXylocYLwEtBY9SCe665bYnNB515uoA==",
-      "requires": {
-        "@babel/runtime": "^7.13.10"
-      }
-    },
-    "@radix-ui/react-compose-refs": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-0.1.0.tgz",
-      "integrity": "sha512-eyclbh+b77k+69Dk72q3694OHrn9B3QsoIRx7ywX341U9RK1ThgQjMFZoPtmZNQTksXHLNEiefR8hGVeFyInGg==",
-      "requires": {
-        "@babel/runtime": "^7.13.10"
-      }
-    },
-    "@radix-ui/react-context": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-0.1.1.tgz",
-      "integrity": "sha512-PkyVX1JsLBioeu0jB9WvRpDBBLtLZohVDT3BB5CTSJqActma8S8030P57mWZb4baZifMvN7KKWPAA40UmWKkQg==",
-      "requires": {
-        "@babel/runtime": "^7.13.10"
-      }
-    },
     "@radix-ui/react-direction": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.0.0.tgz",
       "integrity": "sha512-2HV05lGUgYcA6xgLQ4BKPDmtL+QbIZYH5fCOTAOOcJ5O0QbWS3i9lKaurLzliYUDhORI2Qr3pyjhJh44lKA3rQ==",
-      "requires": {
-        "@babel/runtime": "^7.13.10"
-      }
-    },
-    "@radix-ui/react-presence": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-0.1.2.tgz",
-      "integrity": "sha512-3BRlFZraooIUfRlyN+b/Xs5hq1lanOOo/+3h6Pwu2GMFjkGKKa4Rd51fcqGqnVlbr3jYg+WLuGyAV4KlgqwrQw==",
-      "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-compose-refs": "0.1.0",
-        "@radix-ui/react-use-layout-effect": "0.1.0"
-      }
-    },
-    "@radix-ui/react-primitive": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-0.1.4.tgz",
-      "integrity": "sha512-6gSl2IidySupIMJFjYnDIkIWRyQdbu/AHK7rbICPani+LW4b0XdxBXc46og/iZvuwW8pjCS8I2SadIerv84xYA==",
-      "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-slot": "0.1.2"
-      }
-    },
-    "@radix-ui/react-scroll-area": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-0.1.4.tgz",
-      "integrity": "sha512-QHxRsjy+hsHwQYJ9cCNgSJ5+6ioZu1KhwD1UOXoHNciuFGMX08v+uJPKXIz+ySv03Rx6cOz6f/Fk5aPHRMFi/A==",
-      "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/number": "0.1.0",
-        "@radix-ui/primitive": "0.1.0",
-        "@radix-ui/react-compose-refs": "0.1.0",
-        "@radix-ui/react-context": "0.1.1",
-        "@radix-ui/react-presence": "0.1.2",
-        "@radix-ui/react-primitive": "0.1.4",
-        "@radix-ui/react-use-callback-ref": "0.1.0",
-        "@radix-ui/react-use-direction": "0.1.0",
-        "@radix-ui/react-use-layout-effect": "0.1.0"
-      }
-    },
-    "@radix-ui/react-slot": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-0.1.2.tgz",
-      "integrity": "sha512-ADkqfL+agEzEguU3yS26jfB50hRrwf7U4VTwAOZEmi/g+ITcBWe12yM46ueS/UCIMI9Py+gFUaAdxgxafFvY2Q==",
-      "requires": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-compose-refs": "0.1.0"
-      }
-    },
-    "@radix-ui/react-use-callback-ref": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-0.1.0.tgz",
-      "integrity": "sha512-Va041McOFFl+aV+sejvl0BS2aeHx86ND9X/rVFmEFQKTXCp6xgUK0NGUAGcgBlIjnJSbMYPGEk1xKSSlVcN2Aw==",
-      "requires": {
-        "@babel/runtime": "^7.13.10"
-      }
-    },
-    "@radix-ui/react-use-direction": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-direction/-/react-use-direction-0.1.0.tgz",
-      "integrity": "sha512-NajpY/An9TCPSfOVkgWIdXJV+VuWl67PxB6kOKYmtNAFHvObzIoh8o0n9sAuwSAyFCZVq211FEf9gvVDRhOyiA==",
-      "requires": {
-        "@babel/runtime": "^7.13.10"
-      }
-    },
-    "@radix-ui/react-use-layout-effect": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-0.1.0.tgz",
-      "integrity": "sha512-+wdeS51Y+E1q1Wmd+1xSSbesZkpVj4jsg0BojCbopWvgq5iBvixw5vgemscdh58ep98BwUbsFYnrywFhV9yrVg==",
       "requires": {
         "@babel/runtime": "^7.13.10"
       }
@@ -12239,70 +11755,6 @@
           "requires": {
             "safe-buffer": "~5.1.0"
           }
-        }
-      }
-    },
-    "ecqm-visualizers": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/ecqm-visualizers/-/ecqm-visualizers-0.0.1.tgz",
-      "integrity": "sha512-Ap+c/0c5E4isrPBd1Jfa5fzwDROqD6jRyFu4QkOPdn0BSxIlXFuVr2+af8N4KBf1w4UHZL0V+jIAkXfeml6NBw==",
-      "requires": {
-        "@fhir-typescript/r4-core": "0.0.12-beta.15",
-        "@mantine/core": "^4.2.12",
-        "@mantine/hooks": "^4.2.12"
-      },
-      "dependencies": {
-        "@mantine/core": {
-          "version": "4.2.12",
-          "resolved": "https://registry.npmjs.org/@mantine/core/-/core-4.2.12.tgz",
-          "integrity": "sha512-PZcVUvcSZiZmLR1moKBJFdFIh6a4C+TE2ao91kzTAlH5Qb8t/V3ONbfPk3swHoYr7OSLJQM8vZ7UD5sFDiq0/g==",
-          "requires": {
-            "@mantine/styles": "4.2.12",
-            "@popperjs/core": "^2.9.3",
-            "@radix-ui/react-scroll-area": "^0.1.1",
-            "react-popper": "^2.2.5",
-            "react-textarea-autosize": "^8.3.2"
-          }
-        },
-        "@mantine/hooks": {
-          "version": "4.2.12",
-          "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-4.2.12.tgz",
-          "integrity": "sha512-/2GOsgv1tAUFBXOUV0YBZdDZHj3pHN82Sv1oI/hJMjfIT3ZkGeeiJO8Cw9cBcn76t6caP6Czi3hcuKhjz71O+A==",
-          "requires": {}
-        },
-        "@mantine/styles": {
-          "version": "4.2.12",
-          "resolved": "https://registry.npmjs.org/@mantine/styles/-/styles-4.2.12.tgz",
-          "integrity": "sha512-9q1DzW0UNW/ORMGLHfN2XABOSEm0ZQebhNlLD757R6OQouoLuUf9elUwgGOXSyogMlsAYoy84XbJ3ZbbTm4YCA==",
-          "requires": {
-            "@emotion/cache": "11.7.1",
-            "@emotion/react": "11.7.1",
-            "@emotion/serialize": "1.0.2",
-            "@emotion/utils": "1.0.0",
-            "clsx": "^1.1.1",
-            "csstype": "3.0.9"
-          },
-          "dependencies": {
-            "@emotion/react": {
-              "version": "11.7.1",
-              "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.7.1.tgz",
-              "integrity": "sha512-DV2Xe3yhkF1yT4uAUoJcYL1AmrnO5SVsdfvu+fBuS7IbByDeTVx9+wFmvx9Idzv7/78+9Mgx2Hcmr7Fex3tIyw==",
-              "requires": {
-                "@babel/runtime": "^7.13.10",
-                "@emotion/cache": "^11.7.1",
-                "@emotion/serialize": "^1.0.2",
-                "@emotion/sheet": "^1.1.0",
-                "@emotion/utils": "^1.0.0",
-                "@emotion/weak-memoize": "^0.2.5",
-                "hoist-non-react-statics": "^3.3.1"
-              }
-            }
-          }
-        },
-        "csstype": {
-          "version": "3.0.9",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.9.tgz",
-          "integrity": "sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw=="
         }
       }
     },
@@ -14902,39 +14354,15 @@
         "prop-types": "^15.8.1"
       }
     },
-    "react-fast-compare": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
-      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
-    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
-    "react-popper": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
-      "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
-      "requires": {
-        "react-fast-compare": "^3.0.1",
-        "warning": "^4.0.2"
-      }
-    },
     "react-property": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.0.tgz",
       "integrity": "sha512-kzmNjIgU32mO4mmH5+iUyrqlpFQhF8K2k7eZ4fdLSOPFrD1XgEuSBv9LDEgxRXTMBqMd8ppT0x6TIzqE5pdGdw=="
-    },
-    "react-textarea-autosize": {
-      "version": "8.3.3",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.3.tgz",
-      "integrity": "sha512-2XlHXK2TDxS6vbQaoPbMOfQ8GK7+irc2fVK6QFIcC8GOnH3zI/v481n+j1L0WaPVvKxwesnY93fEfH++sus2rQ==",
-      "requires": {
-        "@babel/runtime": "^7.10.2",
-        "use-composed-ref": "^1.0.0",
-        "use-latest": "^1.0.0"
-      }
     },
     "react-transition-group": {
       "version": "4.4.2",
@@ -15730,14 +15158,6 @@
       "dev": true,
       "requires": {
         "makeerror": "1.0.12"
-      }
-    },
-    "warning": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "requires": {
-        "loose-envify": "^1.0.0"
       }
     },
     "webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@tabler/icons": "^1.105.0",
     "@uiw/react-codemirror": "^4.7.0",
     "dayjs": "^1.11.2",
-    "ecqm-visualizers": "0.0.1",
     "fhirpath": "^2.14.6",
     "file-saver": "^2.0.5",
     "fqm-execution": "git+https://git@github.com/projecttacoma/fqm-execution",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,11 @@
   "dependencies": {
     "@codemirror/lang-json": "^0.20.0",
     "@codemirror/lint": "^0.20.3",
+    "@emotion/cache": "^11.10.7",
     "@emotion/react": "^11.10.0",
+    "@emotion/serialize": "^1.1.1",
     "@emotion/server": "^11.10.0",
+    "@emotion/utils": "^1.2.0",
     "@fhir-typescript/r4-core": "0.0.12-beta.15",
     "@mantine/core": "^5.3.1",
     "@mantine/dates": "^5.3.1",

--- a/state/atoms/detailedResultLookup.ts
+++ b/state/atoms/detailedResultLookup.ts
@@ -1,9 +1,7 @@
-import { CalculatorTypes } from 'fqm-execution';
 import { atom } from 'recoil';
+import { DetailedResult } from '../../util/types';
 
-export const detailedResultLookupState = atom<
-  Record<string, CalculatorTypes.ExecutionResult<CalculatorTypes.DetailedPopulationGroupResult>>
->({
+export const detailedResultLookupState = atom<Record<string, DetailedResult>>({
   key: 'detailedResultLookupState',
   default: {}
 });

--- a/state/atoms/detailedResultLookup.ts
+++ b/state/atoms/detailedResultLookup.ts
@@ -1,0 +1,9 @@
+import { CalculatorTypes } from 'fqm-execution';
+import { atom } from 'recoil';
+
+export const detailedResultLookupState = atom<
+  Record<string, CalculatorTypes.ExecutionResult<CalculatorTypes.DetailedPopulationGroupResult>>
+>({
+  key: 'detailedResultLookupState',
+  default: {}
+});

--- a/state/atoms/measureReportLookup.ts
+++ b/state/atoms/measureReportLookup.ts
@@ -1,6 +1,0 @@
-import { atom } from 'recoil';
-
-export const measureReportLookupState = atom<Record<string, fhir4.MeasureReport>>({
-  key: 'measureReportLookupState',
-  default: {}
-});

--- a/util/MeasureCalculation.ts
+++ b/util/MeasureCalculation.ts
@@ -1,17 +1,18 @@
 import { Calculator, CalculatorTypes } from 'fqm-execution';
 import { TestCaseInfo } from '../state/atoms/patientTestCase';
 import { createPatientBundle } from './fhir/resourceCreation';
+import { DetailedResult } from './types';
 
 /**
  * Takes in a patient's test case info, a measure bundle, and a measurement
- * period start and end and returns a measureReport
+ * period start and end and returns a detailedResult
  */
-export async function calculateMeasureReport(
+export async function calculateDetailedResult(
   patientTestCase: TestCaseInfo,
   mb: fhir4.Bundle,
   mpStart: string | undefined,
   mpEnd: string | undefined
-): Promise<fhir4.MeasureReport> {
+): Promise<DetailedResult> {
   const options: CalculatorTypes.CalculationOptions = {
     calculateHTML: true,
     calculateSDEs: true,
@@ -24,7 +25,6 @@ export async function calculateMeasureReport(
 
   const patientBundle = createPatientBundle(patientTestCase.patient, patientTestCase.resources);
 
-  const mrResults = await Calculator.calculateMeasureReports(mb, [patientBundle], options);
-  const [measureReport] = mrResults.results as fhir4.MeasureReport[];
-  return measureReport;
+  const { results } = await Calculator.calculate(mb, [patientBundle], options);
+  return results[0];
 }

--- a/util/MeasurePopulations.ts
+++ b/util/MeasurePopulations.ts
@@ -26,6 +26,7 @@ export function getMeasurePopulationsForSelection(measure: fhir4.Measure): Multi
   measure.group?.[0]?.population?.forEach(population => {
     const populationCode = population.code?.coding?.[0].code;
     const populationDisplay = population.code?.coding?.[0].display;
+    const populationCriteriaExpression = population.criteria.expression;
     // TODO: determine handling of populations that are not permitted for proportion measures
     if (
       populationCode &&
@@ -34,7 +35,7 @@ export function getMeasurePopulationsForSelection(measure: fhir4.Measure): Multi
     ) {
       measurePopulations.push({
         value: populationCode,
-        label: populationDisplay || populationCode,
+        label: populationCriteriaExpression || populationDisplay || populationCode,
         disabled: false
       });
     }

--- a/util/types.ts
+++ b/util/types.ts
@@ -1,3 +1,5 @@
+import { CalculatorTypes } from 'fqm-execution';
+
 export interface ResourceCodeInfo {
   primaryCodePath: string;
   paths: Record<string, CodePathInfo>;
@@ -8,3 +10,5 @@ export interface CodePathInfo {
   multipleCardinality: boolean;
   choiceType: boolean;
 }
+
+export type DetailedResult = CalculatorTypes.ExecutionResult<CalculatorTypes.DetailedPopulationGroupResult>;


### PR DESCRIPTION
# Summary
This PR replaces uses of `calculateMeasureReports` with `calculate` from `fqm-execution`. Information is now pulled off of the `detailedResults` output rather than the `MeasureReport`. This will make things easier in the future when we want individual episode results from the detailedResults.

## New Behavior
- None. The UI should look and act the same.

## Code Changes
- `utils/types.ts` - Added new `DetailedResult` type to make things easier. In the future, we can export these types from `fqm-execution` differently, but this works for now.
- `util/MeasurePopulations.ts` - Added `populationCriteriaExpression` since that is actually where we get the table headers from now since we are pulling population results from detailedResults rather than the Measure Report. Should I remove `populationCode` and `populationDisplay`?
- `util/MeasureCalculation` - Should I rename this file? Changes `calculateMeasureReport` to `calculateDetailedResult`.
- `measureReportLookup.ts` -> `detailedResultLookup.ts` 
- `pages/generate-test-cases.tsx` / `components/resource-creation/ResourcePanel.tsx` / `component/resource-creation/ResourceDisplay.tsx` / `components/patient-creation/PatientCreationPanel.tsx` / `components/calculation/PopulationCalculation.tsx` - calculateMeasureReports to calculateDetailedResults switcheroos
- `MeasureHighlightingPanel.tsx` - logic highlighting comes off of `detailedResults.html` property now
- `PopulationComparisonTable.tsx` - Gets the key from the `criteriaExpression` now 
- `PopulationResultsTable.tsx` - `ecqm-visualizers` takes in a MeasureReport, so I decided to just bring in the code from that repo in here and change it to take in detailedResults. Let me know if I missed anything. Sorry `ecqm-visualizers` :(
- `package.json` / `package-lock.json` - Removed `ecqm-visualizers` and added the dependencies we need that came from it
- `PopulationCalculation.test.tsx` / `PopulationComparisonTable.test.tsx` - fixed affected unit tests

# Testing Guidance
- `npm run check`
- `npm run dev` and navigate to http://localhost:3000/
- Make sure the app runs and looks the same!

NOTE: There are some errors in the unit tests that are not being picked up. Nat fixes them in #63, so just ignore them for now.