### PR TITLE
Add Full URL to Export Bundles

### DIFF
--- a/__tests__/components/calculation/PopulationCalculation.test.tsx
+++ b/__tests__/components/calculation/PopulationCalculation.test.tsx
@@ -80,6 +80,7 @@ describe('PopulationCalculation', () => {
           resourceType: 'Patient',
           name: [{ given: ['Test123'], family: 'Patient456' }]
         },
+        fullUrl: 'urn:uuid:testPatient',
         resources: []
       }
     });
@@ -105,6 +106,7 @@ describe('PopulationCalculation', () => {
           resourceType: 'Patient',
           name: [{ given: ['Test123'], family: 'Patient456' }]
         },
+        fullUrl: 'urn:uuid:testPatient',
         resources: [
           {
             resource: {
@@ -174,6 +176,7 @@ describe('PopulationCalculation', () => {
           resourceType: 'Patient',
           name: [{ given: ['Test123'], family: 'Patient456' }]
         },
+        fullUrl: 'urn:uuid:testPatient',
         resources: [
           {
             resource: {
@@ -243,6 +246,7 @@ describe('PopulationCalculation', () => {
           resourceType: 'Patient',
           name: [{ given: ['Test123'], family: 'Patient456' }]
         },
+        fullUrl: 'urn:uuid:testPatient',
         resources: [
           {
             resource: {

--- a/__tests__/components/calculation/PopulationCalculation.test.tsx
+++ b/__tests__/components/calculation/PopulationCalculation.test.tsx
@@ -107,10 +107,13 @@ describe('PopulationCalculation', () => {
         },
         resources: [
           {
-            resourceType: 'Procedure',
-            id: 'test-id',
-            status: 'completed',
-            subject: {}
+            resource: {
+              resourceType: 'Procedure',
+              id: 'test-id',
+              status: 'completed',
+              subject: {}
+            },
+            fullUrl: 'urn:uuid:test-id'
           }
         ]
       }
@@ -173,10 +176,13 @@ describe('PopulationCalculation', () => {
         },
         resources: [
           {
-            resourceType: 'Procedure',
-            id: 'test-id',
-            status: 'completed',
-            subject: {}
+            resource: {
+              resourceType: 'Procedure',
+              id: 'test-id',
+              status: 'completed',
+              subject: {}
+            },
+            fullUrl: 'urn:uuid:test-id'
           }
         ]
       }
@@ -239,10 +245,13 @@ describe('PopulationCalculation', () => {
         },
         resources: [
           {
-            resourceType: 'Procedure',
-            id: 'test-id',
-            status: 'completed',
-            subject: {}
+            resource: {
+              resourceType: 'Procedure',
+              id: 'test-id',
+              status: 'completed',
+              subject: {}
+            },
+            fullUrl: 'urn:uuid:test-id'
           }
         ]
       }

--- a/__tests__/components/calculation/PopulationComparisonTable.test.tsx
+++ b/__tests__/components/calculation/PopulationComparisonTable.test.tsx
@@ -128,6 +128,7 @@ const EXAMPLE_PATIENT: fhir4.Patient = {
 const MOCK_TEST_CASE: TestCase = {
   'example-pt': {
     patient: EXAMPLE_PATIENT,
+    fullUrl: 'urn:uuid:testPatient',
     resources: [],
     desiredPopulations: ['initial-population']
   }

--- a/__tests__/components/patient-creation/PatientCreationPanel.test.tsx
+++ b/__tests__/components/patient-creation/PatientCreationPanel.test.tsx
@@ -91,6 +91,7 @@ describe('PatientCreationPanel', () => {
           resourceType: 'Patient',
           name: [{ given: ['Test123'], family: 'Patient456' }]
         },
+        fullUrl: 'urn:uuid:testPatient',
         resources: []
       }
     });
@@ -115,6 +116,7 @@ describe('PatientCreationPanel', () => {
           resourceType: 'Patient',
           name: [{ given: ['Test123'], family: 'Patient456' }]
         },
+        fullUrl: 'urn:uuid:testPatient',
         resources: []
       }
     });
@@ -149,6 +151,7 @@ describe('PatientCreationPanel', () => {
           resourceType: 'Patient',
           name: [{ given: ['Test123'], family: 'Patient456' }]
         },
+        fullUrl: 'urn:uuid:testPatient',
         resources: []
       }
     });
@@ -183,6 +186,7 @@ describe('PatientCreationPanel', () => {
           resourceType: 'Patient',
           name: [{ given: ['Test123'], family: 'Patient456' }]
         },
+        fullUrl: 'urn:uuid:testPatient',
         resources: [
           {
             resource: {

--- a/__tests__/components/patient-creation/PatientCreationPanel.test.tsx
+++ b/__tests__/components/patient-creation/PatientCreationPanel.test.tsx
@@ -10,6 +10,7 @@ jest.mock('../../../util/downloadUtil', () => ({
   download: jest.fn()
 }));
 
+// Mock out the getClientRects function to avoid warnings
 document.createRange = () => {
   const range = new Range();
 

--- a/__tests__/components/patient-creation/PatientCreationPanel.test.tsx
+++ b/__tests__/components/patient-creation/PatientCreationPanel.test.tsx
@@ -10,6 +10,20 @@ jest.mock('../../../util/downloadUtil', () => ({
   download: jest.fn()
 }));
 
+document.createRange = () => {
+  const range = new Range();
+
+  range.getBoundingClientRect = jest.fn();
+
+  range.getClientRects = jest.fn(() => ({
+    item: () => null,
+    length: 0,
+    [Symbol.iterator]: jest.fn()
+  }));
+
+  return range;
+};
+
 describe('PatientCreationPanel', () => {
   it('should not render modal by default', () => {
     const MockPatients = getMockRecoilState(patientTestCaseState, {});
@@ -170,10 +184,13 @@ describe('PatientCreationPanel', () => {
         },
         resources: [
           {
-            resourceType: 'Procedure',
-            id: 'test-id',
-            status: 'completed',
-            subject: {}
+            resource: {
+              resourceType: 'Procedure',
+              id: 'test-id',
+              status: 'completed',
+              subject: {}
+            },
+            fullUrl: 'urn:uuid:test-id'
           }
         ]
       }

--- a/__tests__/components/resource-creation/ResourceDisplay.test.tsx
+++ b/__tests__/components/resource-creation/ResourceDisplay.test.tsx
@@ -25,20 +25,23 @@ const MOCK_TEST_CASE_POPULATED: TestCase = {
     },
     resources: [
       {
-        resourceType: 'Procedure',
-        id: 'example-procedure',
-        status: 'completed',
-        subject: {
-          reference: 'Patient/example-pt'
+        resource: {
+          resourceType: 'Procedure',
+          id: 'example-procedure',
+          status: 'completed',
+          subject: {
+            reference: 'Patient/example-pt'
+          },
+          code: {
+            coding: [
+              {
+                code: 'example-code',
+                display: 'Example Code Display'
+              }
+            ]
+          }
         },
-        code: {
-          coding: [
-            {
-              code: 'example-code',
-              display: 'Example Code Display'
-            }
-          ]
-        }
+        fullUrl: 'urn:uuid:example-procedure'
       }
     ]
   }

--- a/__tests__/components/resource-creation/ResourceDisplay.test.tsx
+++ b/__tests__/components/resource-creation/ResourceDisplay.test.tsx
@@ -12,6 +12,7 @@ const MOCK_TEST_CASE_EMPTY: TestCase = {
       id: 'example-pt',
       name: [{ given: ['Test123'], family: 'Patient456' }]
     },
+    fullUrl: 'urn:uuid:example-pt',
     resources: []
   }
 };
@@ -23,6 +24,7 @@ const MOCK_TEST_CASE_POPULATED: TestCase = {
       id: 'example-pt',
       name: [{ given: ['Test123'], family: 'Patient456' }]
     },
+    fullUrl: 'urn:uuid:example-pt',
     resources: [
       {
         resource: {

--- a/__tests__/components/resource-creation/ResourcePanel.test.tsx
+++ b/__tests__/components/resource-creation/ResourcePanel.test.tsx
@@ -36,6 +36,7 @@ describe('ResourcePanel', () => {
             }
           ]
         } as fhir4.Patient,
+        fullUrl: 'urn:uuid:example-pt',
         resources: []
       }
     });
@@ -69,6 +70,7 @@ describe('ResourcePanel', () => {
             }
           ]
         } as fhir4.Patient,
+        fullUrl: 'urn:uuid:example-pt',
         resources: []
       }
     });
@@ -105,6 +107,7 @@ describe('ResourcePanel', () => {
             }
           ]
         } as fhir4.Patient,
+        fullUrl: 'urn:uuid:example-pt',
         resources: []
       }
     });

--- a/__tests__/components/resource-creation/ResourceSelection.test.tsx
+++ b/__tests__/components/resource-creation/ResourceSelection.test.tsx
@@ -73,6 +73,7 @@ const MOCK_TEST_CASE_POPULATED: TestCase = {
       id: 'example-pt',
       name: [{ given: ['Test123'], family: 'Patient456' }]
     },
+    fullUrl: 'urn:uuid:example-pt',
     resources: [
       {
         resource: {

--- a/__tests__/components/resource-creation/ResourceSelection.test.tsx
+++ b/__tests__/components/resource-creation/ResourceSelection.test.tsx
@@ -75,20 +75,23 @@ const MOCK_TEST_CASE_POPULATED: TestCase = {
     },
     resources: [
       {
-        resourceType: 'Procedure',
-        id: 'example-procedure',
-        status: 'completed',
-        subject: {
-          reference: 'Patient/example-pt'
+        resource: {
+          resourceType: 'Procedure',
+          id: 'example-procedure',
+          status: 'completed',
+          subject: {
+            reference: 'Patient/example-pt'
+          },
+          code: {
+            coding: [
+              {
+                code: 'example-code',
+                display: 'Example Code Display'
+              }
+            ]
+          }
         },
-        code: {
-          coding: [
-            {
-              code: 'example-code',
-              display: 'Example Code Display'
-            }
-          ]
-        }
+        fullUrl: 'urn:uuid:example-procedure'
       }
     ]
   }

--- a/__tests__/components/utils/PopulationMultiSelect.test.tsx
+++ b/__tests__/components/utils/PopulationMultiSelect.test.tsx
@@ -60,6 +60,7 @@ const EXAMPLE_PATIENT: fhir4.Patient = {
 const MOCK_TEST_CASE: TestCase = {
   'example-pt': {
     patient: EXAMPLE_PATIENT,
+    fullUrl: 'urn:uuid:example-pt',
     resources: []
   }
 };

--- a/__tests__/utils/fhir/resourceCreation.test.ts
+++ b/__tests__/utils/fhir/resourceCreation.test.ts
@@ -192,36 +192,42 @@ const PATIENT_RESOURCE_W_DETAILS: fhir4.Patient = {
   ]
 };
 
-const ENCOUNTER_RESOURCE: fhir4.Encounter = {
-  resourceType: 'Encounter',
-  id: 'Encounter1',
-  status: 'finished',
-  class: { code: 'AMB' },
-  type: [
-    {
-      coding: [
-        {
-          system: 'https://www.cms.gov/Medicare/Coding/MedHCPCSGenInfo/index.html',
-          version: '2018',
-          code: 'G0438',
-          display: 'Annual wellness visit; includes a personalized prevention plan of service (pps), initial visit'
-        }
-      ]
-    }
-  ]
-};
-
-const OBSERVATION_RESOURCE: fhir4.Observation = {
-  resourceType: 'Observation',
-  id: 'Observation1',
-  code: {
-    coding: [
+const ENCOUNTER_RESOURCE: fhir4.BundleEntry = {
+  resource: {
+    resourceType: 'Encounter',
+    id: 'Encounter1',
+    status: 'finished',
+    class: { code: 'AMB' },
+    type: [
       {
-        code: 'Test Obs'
+        coding: [
+          {
+            system: 'https://www.cms.gov/Medicare/Coding/MedHCPCSGenInfo/index.html',
+            version: '2018',
+            code: 'G0438',
+            display: 'Annual wellness visit; includes a personalized prevention plan of service (pps), initial visit'
+          }
+        ]
       }
     ]
   },
-  status: 'final'
+  fullUrl: 'urn:uuid:Encounter1'
+};
+
+const OBSERVATION_RESOURCE: fhir4.BundleEntry = {
+  resource: {
+    resourceType: 'Observation',
+    id: 'Observation1',
+    code: {
+      coding: [
+        {
+          code: 'Test Obs'
+        }
+      ]
+    },
+    status: 'final'
+  },
+  fullUrl: 'urn:uuid:Observation1'
 };
 
 const EXPECTED_CQFM_NO_POPS_OUTPUT = {
@@ -459,7 +465,8 @@ describe('createPatientBundle', () => {
           request: {
             method: 'PUT',
             url: 'Patient/Patient1'
-          }
+          },
+          fullUrl: 'urn:uuid:Patient1'
         }
       ]
     };
@@ -478,21 +485,24 @@ describe('createPatientBundle', () => {
           request: {
             method: 'PUT',
             url: 'Patient/Patient1'
-          }
+          },
+          fullUrl: 'urn:uuid:Patient1'
         },
         {
-          resource: ENCOUNTER_RESOURCE,
+          resource: ENCOUNTER_RESOURCE.resource,
           request: {
             method: 'PUT',
             url: 'Encounter/Encounter1'
-          }
+          },
+          fullUrl: 'urn:uuid:Encounter1'
         },
         {
-          resource: OBSERVATION_RESOURCE,
+          resource: OBSERVATION_RESOURCE.resource,
           request: {
             method: 'PUT',
             url: 'Observation/Observation1'
-          }
+          },
+          fullUrl: 'urn:uuid:Observation1'
         }
       ]
     };
@@ -504,14 +514,14 @@ describe('createPatientBundle', () => {
 describe('createCopiedResources', () => {
   it('should update references to a patient when cloned', () => {
     const resources = createCopiedResources(
-      [PROCEDURE_RESOURCE_WITH_FULL_SUMMARY],
+      [{ resource: PROCEDURE_RESOURCE_WITH_FULL_SUMMARY }],
       'procedure-reference',
       'new-reference'
     );
-    const procedure: fhir4.Procedure = resources[0] as fhir4.Procedure;
+    const procedure = resources[0].resource as fhir4.Procedure;
     expect(procedure.id).not.toEqual(PROCEDURE_RESOURCE_WITH_FULL_SUMMARY.id);
     expect(procedure.subject.reference).toEqual('Patient/new-reference');
-    expect(PROCEDURE_RESOURCE_WITH_FULL_SUMMARY.subject.reference).toEqual('Patient/procedure-reference');
+    expect(PROCEDURE_RESOURCE_WITH_FULL_SUMMARY.subject?.reference).toEqual('Patient/procedure-reference');
   });
 });
 

--- a/__tests__/utils/import.test.ts
+++ b/__tests__/utils/import.test.ts
@@ -7,7 +7,7 @@ const TEST_PATIENT: fhir4.Patient = {
 
 const TEST_CONDITION: fhir4.Condition = {
   resourceType: 'Condition',
-  id: 'test-patient',
+  id: 'test-condition',
   subject: {
     reference: 'Patient/test-patient'
   }
@@ -116,7 +116,8 @@ describe('bundleToTestCase', () => {
 
     expect(result).toEqual({
       patient: TEST_PATIENT,
-      resources: [TEST_CONDITION],
+      fullUrl: 'urn:uuid:test-patient',
+      resources: [{ resource: TEST_CONDITION, fullUrl: 'urn:uuid:test-condition' }],
       desiredPopulations: []
     });
   });
@@ -180,7 +181,8 @@ describe('bundleToTestCase', () => {
 
     expect(result).toEqual({
       patient: TEST_PATIENT,
-      resources: [TEST_CONDITION],
+      fullUrl: 'urn:uuid:test-patient',
+      resources: [{ resource: TEST_CONDITION, fullUrl: 'urn:uuid:test-condition' }],
       desiredPopulations: ['initial-population', 'numerator', 'denominator']
     });
   });

--- a/components/patient-creation/PatientCreationPanel.tsx
+++ b/components/patient-creation/PatientCreationPanel.tsx
@@ -122,9 +122,7 @@ function PatientCreationPanel() {
           patient: pt,
           fullUrl: draftState[patientId]?.fullUrl ?? `urn:uuid:${patientId}`,
           resources: resources,
-          desiredPopulations: copiedPatient
-            ? currentPatients[copiedPatient].desiredPopulations
-            : currentPatients[patientId]?.desiredPopulations
+          desiredPopulations: currentPatients[patientId]?.desiredPopulations
         };
       });
       setCurrentPatients(nextPatientState);

--- a/components/patient-creation/PatientCreationPanel.tsx
+++ b/components/patient-creation/PatientCreationPanel.tsx
@@ -108,7 +108,7 @@ function PatientCreationPanel() {
     if (pt.id) {
       const patientId = pt.id;
 
-      let resources: fhir4.FhirResource[];
+      let resources: fhir4.BundleEntry[];
       // save new resources for a copied patient
       if (copiedPatient) {
         const pat = currentPatients[copiedPatient];
@@ -120,8 +120,11 @@ function PatientCreationPanel() {
       const nextPatientState = produce(currentPatients, draftState => {
         draftState[patientId] = {
           patient: pt,
+          fullUrl: draftState[patientId]?.fullUrl ?? `urn:uuid:${patientId}`,
           resources: resources,
-          desiredPopulations: currentPatients[patientId]?.desiredPopulations
+          desiredPopulations: copiedPatient
+            ? currentPatients[copiedPatient].desiredPopulations
+            : currentPatients[patientId]?.desiredPopulations
         };
       });
       setCurrentPatients(nextPatientState);
@@ -184,7 +187,12 @@ function PatientCreationPanel() {
 
   const exportPatientTestCase = (id: string) => {
     const bundleString: string = JSON.stringify(
-      createPatientBundle(currentPatients[id].patient, currentPatients[id].resources, currentTestMRLookup[id]),
+      createPatientBundle(
+        currentPatients[id].patient,
+        currentPatients[id].resources,
+        currentPatients[id].fullUrl,
+        currentTestMRLookup[id]
+      ),
       null,
       2
     );
@@ -233,7 +241,12 @@ function PatientCreationPanel() {
     if (measureBundleFolder) {
       Object.keys(currentPatients).forEach(id => {
         const bundleString: string = JSON.stringify(
-          createPatientBundle(currentPatients[id].patient, currentPatients[id].resources, currentTestMRLookup[id]),
+          createPatientBundle(
+            currentPatients[id].patient,
+            currentPatients[id].resources,
+            currentPatients[id].fullUrl,
+            currentTestMRLookup[id]
+          ),
           null,
           2
         );

--- a/components/resource-creation/ResourceDisplay.tsx
+++ b/components/resource-creation/ResourceDisplay.tsx
@@ -170,7 +170,6 @@ function ResourceDisplay() {
   const getInitialResource = () => {
     if (isResourceModalOpen) {
       if (currentResource && selectedPatient) {
-        console.log(currentResource);
         return JSON.stringify(
           currentTestCases[selectedPatient].resources.filter(r => r.resource?.id === currentResource)[0].resource,
           null,
@@ -197,7 +196,6 @@ function ResourceDisplay() {
   };
 
   const getConfirmationModalText = (resourceId: string | null) => {
-    console.log();
     if (selectedPatient && resourceId) {
       const resourceIndex = currentTestCases[selectedPatient].resources.findIndex(r => r.resource?.id === resourceId);
       const resource = currentTestCases[selectedPatient].resources[resourceIndex].resource;

--- a/components/resource-creation/ResourceDisplay.tsx
+++ b/components/resource-creation/ResourceDisplay.tsx
@@ -199,9 +199,9 @@ function ResourceDisplay() {
     if (selectedPatient && resourceId) {
       const resourceIndex = currentTestCases[selectedPatient].resources.findIndex(r => r.resource?.id === resourceId);
       const resource = currentTestCases[selectedPatient].resources[resourceIndex].resource;
-      return `Are you sure you want to delete ${resource?.resourceType} ${getFhirResourceSummary(
-        resource as fhir4.FhirResource
-      )}?`;
+      if (resource) {
+        return `Are you sure you want to delete ${resource.resourceType} ${getFhirResourceSummary(resource)}?`;
+      }
     }
   };
 
@@ -222,15 +222,16 @@ function ResourceDisplay() {
       />
       {selectedPatient && selectedDataRequirement && currentTestCases[selectedPatient].resources.length > 0 && (
         <Stack data-testid="resource-display-stack">
-          {currentTestCases[selectedPatient].resources.map(resource => {
-            if (resource.resource) {
+          {currentTestCases[selectedPatient].resources.map(bundleEntry => {
+            const resource = bundleEntry.resource;
+            if (resource) {
               return (
                 <ResourceInfoCard
-                  key={resource.resource.id}
-                  resourceType={resource.resource.resourceType}
-                  label={getFhirResourceSummary(resource.resource)}
-                  onEditClick={() => openResourceModal(resource.resource?.id)}
-                  onDeleteClick={() => openConfirmationModal(resource.resource?.id)}
+                  key={resource.id}
+                  resourceType={resource.resourceType}
+                  label={getFhirResourceSummary(resource)}
+                  onEditClick={() => openResourceModal(resource.id)}
+                  onDeleteClick={() => openConfirmationModal(resource.id)}
                 />
               );
             }

--- a/state/atoms/patientTestCase.ts
+++ b/state/atoms/patientTestCase.ts
@@ -2,7 +2,8 @@ import { atom } from 'recoil';
 
 export interface TestCaseInfo {
   patient: fhir4.Patient;
-  resources: fhir4.FhirResource[];
+  fullUrl?: string;
+  resources: fhir4.BundleEntry[];
   desiredPopulations?: string[];
 }
 

--- a/state/atoms/patientTestCase.ts
+++ b/state/atoms/patientTestCase.ts
@@ -2,7 +2,7 @@ import { atom } from 'recoil';
 
 export interface TestCaseInfo {
   patient: fhir4.Patient;
-  fullUrl?: string;
+  fullUrl: string;
   resources: fhir4.BundleEntry[];
   desiredPopulations?: string[];
 }

--- a/util/fhir/resourceCreation.ts
+++ b/util/fhir/resourceCreation.ts
@@ -36,12 +36,12 @@ export function createPatientResourceString(birthDate: string): string {
 }
 
 /**
- * Creates copies of all passed in resources (without references maintained) and gives them
- * new resource ids. Replaces all patient references to the patient oldId with newId
- * @param copyResources {fhir4.FhirResource[]} array of fhir resources to be copied
- * @param oldId {String} a patient id that the copyResources may reference
- * @param newId {String} a patient id that should replace oldId in references
- * @returns {fhir4.FhirResource[]} array of new resource copies
+ * Creates copies of all passed in Bundle entries (without references maintained) and gives them
+ * new resource ids. Replaces all patient references to the patient oldPatientId with newPatientId
+ * @param copyResources array of fhir Bundle entries to be copied
+ * @param oldPatientId  a patient id that the copyResources may reference
+ * @param newPatientId a patient id that should replace oldId in references
+ * @returns array of new Bundle entry copies
  */
 export function createCopiedResources(
   copyResources: fhir4.BundleEntry[],

--- a/util/fhir/resourceCreation.ts
+++ b/util/fhir/resourceCreation.ts
@@ -44,18 +44,23 @@ export function createPatientResourceString(birthDate: string): string {
  * @returns {fhir4.FhirResource[]} array of new resource copies
  */
 export function createCopiedResources(
-  copyResources: fhir4.FhirResource[],
-  oldId: string,
-  newId: string
-): fhir4.FhirResource[] {
-  const resources: fhir4.FhirResource[] = copyResources.map(cr => {
-    let resourceString = JSON.stringify(cr);
-    const idRegexp = new RegExp(`Patient/${oldId}`, 'g');
-    resourceString = resourceString.replace(idRegexp, `Patient/${newId}`);
-    const resource: fhir4.FhirResource = JSON.parse(resourceString);
-    resource.id = uuidv4();
+  copyResources: fhir4.BundleEntry[],
+  oldPatientId: string,
+  newPatientId: string
+): fhir4.BundleEntry[] {
+  const resources: fhir4.BundleEntry[] = copyResources.map(cr => {
+    let entryString = JSON.stringify(cr);
+    const idRegexp = new RegExp(`Patient/${oldPatientId}`, 'g');
+    entryString = entryString.replace(idRegexp, `Patient/${newPatientId}`);
+    const entry: fhir4.BundleEntry = JSON.parse(entryString);
+    if (entry.resource) {
+      const newResourceId = uuidv4();
+      entry.resource.id = newResourceId;
+      entry.fullUrl = `urn:uuid:${newResourceId}`;
+    }
+
     // Note: this does not update potential cross-resource references, which we may want to support in the future
-    return resource;
+    return entry;
   });
   return resources;
 }
@@ -97,12 +102,13 @@ export function createCopiedPatientResource(copyPatient: fhir4.Patient): fhir4.P
  * Creates a string representing a patient bundle resource. Creates using a patient resource and
  * an array of the patient's associated resources
  * @param {Object} patient FHIR Patient object
- * @param {Array} resources array of FHIR resources associated with the patient
+ * @param {Array} entries array of FHIR BundleEntries associated with the patient
  * @returns {String} representation of a FHIR patient bundle resource
  */
 export function createPatientBundle(
   patient: fhir4.Patient,
-  resources: fhir4.FhirResource[],
+  entries: fhir4.BundleEntry[],
+  fullUrl?: string,
   testMeasureReport?: fhir4.MeasureReport
 ): fhir4.Bundle {
   const bundle: fhir4.Bundle = {
@@ -115,19 +121,19 @@ export function createPatientBundle(
         request: {
           method: 'PUT',
           url: `Patient/${patient.id}`
-        }
+        },
+        fullUrl: fullUrl ?? `urn:uuid:${patient.id}`
       }
     ]
   };
-  resources.forEach(resource => {
-    const entry: fhir4.BundleEntry = {
-      resource: resource,
+  entries.forEach(entry => {
+    bundle.entry?.push({
+      ...entry,
       request: {
         method: 'PUT',
-        url: `${resource.resourceType}/${resource.id}`
+        url: `${entry.resource?.resourceType}/${entry.resource?.id}`
       }
-    };
-    bundle.entry?.push(entry);
+    });
   });
   if (testMeasureReport) {
     bundle.entry?.push({
@@ -135,7 +141,8 @@ export function createPatientBundle(
       request: {
         method: 'PUT',
         url: `MeasureReport/${testMeasureReport.id}`
-      }
+      },
+      fullUrl: `urn:uuid:${testMeasureReport.id}`
     });
   }
   return bundle;

--- a/util/import.ts
+++ b/util/import.ts
@@ -64,11 +64,12 @@ export function bundleToTestCase(bundle: fhir4.Bundle, populationGroupCodes: str
 
   return {
     patient: patientResource,
+    fullUrl: patientEntry?.fullUrl ?? `urn:uuid:${patientResource.id}`,
     resources: bundle.entry
       .filter(e => {
         return e.resource?.resourceType !== 'Patient' && !isTestCaseMeasureReport(e);
       })
-      .map(e => e.resource) as fhir4.FhirResource[],
+      .map(e => ({ fullUrl: e.fullUrl ?? `urn:uuid:${e.resource?.id}`, resource: e.resource })),
     desiredPopulations
   };
 }


### PR DESCRIPTION
# Summary
Adds a `fullUrl` to each exported bundle entry. Preserves `fullUrls` from imported bundles
Open Questions: 
- Should we preserve the `fullUrl` for imported testCaseMeasureReports?
- Should we update the `fullUrl` if the id of an existing resource is updated?

## New Behavior
When a patient test case is exported, each entry in the bundle will now have a `fullUrl` field. This `fullUrl` will be preserved if the patient test case was initially an imported case that had `fullUrls` defined, or will be generated in the `urn:uuid` style

## Code Changes
 - Updated `PatientTestCase` to store a fullUrl for the Patient and an array of BundleEntries instead of resources to preserve `fullUrl` field
 - Updated `createPatientBundle` to take in a `fullUrl` for the patient and add `fullUrl`s to the bundle entries
 - Updated all components that access resources to point to the nested `entry.resource`
 - Updated patient cloning to update `fullUrl`s for cloned patient as well
 - Updated testing 

# Testing Guidance
 - `npm run check`
 - `npm run dev`
 - Upload a measure and create a few new patient test cases, each with a few resources
 - Export a single test case and ensure that the exported bundle has `fullUrl` fields for all the bundle entries
 - Clone a patient
 - Export all test cases and ensure they all have `fullUrl` fields. Also ensure that the cloned test case has appropriate `fullUrl`s that match the ids of the cloned resources.
 - Restart and import one of your patient test cases
 - Now export the test case again and ensure the `fullUrl`s match from the import