### PR TITLE
Searchable Expressions

### DIFF
--- a/__tests__/components/calculation/PopulationComparisonTable.test.tsx
+++ b/__tests__/components/calculation/PopulationComparisonTable.test.tsx
@@ -158,7 +158,7 @@ describe('PopulationComparisonTable', () => {
             <MockSelectedPatient />
             <MockDetailedResultLookup />
             <Suspense>
-              <PopulationComparisonTable patientId={'example-pt'} />
+              <PopulationComparisonTable patientId={'example-pt'} defIds={{}} />
             </Suspense>
           </>
         )

--- a/components/calculation/MeasureHighlightingPanel.tsx
+++ b/components/calculation/MeasureHighlightingPanel.tsx
@@ -32,8 +32,6 @@ export default function MeasureHighlightingPanel({ patientId }: MeasureHighlight
       replace: elem => {
         if (elem.type === 'text') {
           const data = (elem as Text).data;
-          console.log(data);
-          console.log(data.match(expressionDefRegex));
           if (data.match(expressionDefRegex)) {
             const splitData = data.split('"');
             defIds[splitData[1]] = splitData[1].toLowerCase().replace(' ', '-');

--- a/components/calculation/MeasureHighlightingPanel.tsx
+++ b/components/calculation/MeasureHighlightingPanel.tsx
@@ -6,7 +6,12 @@ import { detailedResultLookupState } from '../../state/atoms/detailedResultLooku
 import { useMemo } from 'react';
 import { Text } from 'domhandler';
 
-const expressionDefRegex = new RegExp(/^define\s*.*?\".*?\"\s*:.*?/);
+/**
+ * This regex matches any string that includes the substring "define" or "define function"
+ * followed by a string of any length in quotes
+ */
+const expressionDefRegex = new RegExp(/(define(?:\s+function)?\s+)(["'])(.*?)\2/gi);
+
 const useStyles = createStyles({
   highlightedMarkup: {
     '& pre': {

--- a/components/calculation/MeasureHighlightingPanel.tsx
+++ b/components/calculation/MeasureHighlightingPanel.tsx
@@ -3,7 +3,10 @@ import { useRecoilValue } from 'recoil';
 import parse from 'html-react-parser';
 import PopulationComparisonTable from './PopulationComparisonTable';
 import { detailedResultLookupState } from '../../state/atoms/detailedResultLookup';
+import { useMemo } from 'react';
+import { Text } from 'domhandler';
 
+const expressionDefRegex = new RegExp(/^define\s*.*?\".*?\"\s*:.*?/);
 const useStyles = createStyles({
   highlightedMarkup: {
     '& pre': {
@@ -23,13 +26,29 @@ export interface MeasureHighlightingPanelProps {
 export default function MeasureHighlightingPanel({ patientId }: MeasureHighlightingPanelProps) {
   const { classes } = useStyles();
   const detailedResultLookup = useRecoilValue(detailedResultLookupState);
+  const { parsedHTML, defIds } = useMemo(() => {
+    const defIds: Record<string, string> = {};
+    const parsedHTML = parse(detailedResultLookup[patientId]?.detailedResults?.[0].html || '', {
+      replace: elem => {
+        if (elem.type === 'text') {
+          const data = (elem as Text).data;
+          console.log(data);
+          console.log(data.match(expressionDefRegex));
+          if (data.match(expressionDefRegex)) {
+            const splitData = data.split('"');
+            defIds[splitData[1]] = splitData[1].toLowerCase().replace(' ', '-');
+            return <span id={defIds[splitData[1]]}>{data}</span>;
+          }
+        }
+      }
+    });
+    return { parsedHTML, defIds };
+  }, [detailedResultLookup, patientId]);
 
   return (
     <>
-      <PopulationComparisonTable patientId={patientId} />
-      <div className={classes.highlightedMarkup}>
-        {parse(detailedResultLookup[patientId]?.detailedResults?.[0].html || '')}
-      </div>
+      <PopulationComparisonTable patientId={patientId} defIds={defIds} />
+      <div className={classes.highlightedMarkup}>{parsedHTML}</div>
     </>
   );
 }

--- a/components/calculation/PopulationComparisonTable.tsx
+++ b/components/calculation/PopulationComparisonTable.tsx
@@ -4,7 +4,7 @@ import { patientTestCaseState } from '../../state/atoms/patientTestCase';
 import { measureBundleState } from '../../state/atoms/measureBundle';
 import { useMemo, useState } from 'react';
 import { getMeasurePopulationsForSelection, MultiSelectData, getPopShorthand } from '../../util/MeasurePopulations';
-import { InfoCircle } from 'tabler-icons-react';
+import { InfoCircle, Search } from 'tabler-icons-react';
 import { detailedResultLookupState } from '../../state/atoms/detailedResultLookup';
 import { DetailedPopulationGroupResult, PopulationResult } from 'fqm-execution/build/types/Calculator';
 import React from 'react';
@@ -314,11 +314,13 @@ export default function PopulationComparisonTable({ patientId, defIds }: Populat
           </tbody>
         </Table>
         <Autocomplete
-          data={Object.keys(defIds)}
+          data={Object.keys(defIds).sort((a, b) => (a < b ? -1 : 1))}
           value={searchValue}
           onChange={setSearchValue}
           dropdownComponent={ScrollArea}
           maxDropdownHeight={200}
+          placeholder="Expression Name"
+          icon={<Search />}
           nothingFound={
             <Text align="left" style={{ paddingLeft: 10 }}>
               No Matches

--- a/components/calculation/PopulationComparisonTable.tsx
+++ b/components/calculation/PopulationComparisonTable.tsx
@@ -44,7 +44,7 @@ export default function PopulationComparisonTable({ patientId, defIds }: Populat
   const detailedResultLookup = useRecoilValue(detailedResultLookupState);
   const currentPatients = useRecoilValue(patientTestCaseState);
   const [opened, setOpened] = useState(false);
-  const [searchValue, setSearchValue] = useState<string>('');
+  const [searchValue, setSearchValue] = useState('');
 
   const measure = useMemo(() => {
     return measureBundle.content?.entry?.find(e => e.resource?.resourceType === 'Measure')?.resource as fhir4.Measure;

--- a/components/calculation/PopulationComparisonTable.tsx
+++ b/components/calculation/PopulationComparisonTable.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, Autocomplete, createStyles, Group, Popover, Table, Text } from '@mantine/core';
+import { ActionIcon, Autocomplete, createStyles, Group, Popover, ScrollArea, Table, Text } from '@mantine/core';
 import { useRecoilValue } from 'recoil';
 import { patientTestCaseState } from '../../state/atoms/patientTestCase';
 import { measureBundleState } from '../../state/atoms/measureBundle';
@@ -317,6 +317,14 @@ export default function PopulationComparisonTable({ patientId, defIds }: Populat
           data={Object.keys(defIds)}
           value={searchValue}
           onChange={setSearchValue}
+          dropdownComponent={ScrollArea}
+          maxDropdownHeight={200}
+          nothingFound={
+            <Text align="left" style={{ paddingLeft: 10 }}>
+              No Matches
+            </Text>
+          }
+          limit={100}
           label="Search CQL Expression Definition"
           onItemSubmit={item => {
             document.getElementById(defIds[item.value])?.scrollIntoView({ behavior: 'smooth' });

--- a/components/calculation/PopulationComparisonTable.tsx
+++ b/components/calculation/PopulationComparisonTable.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, createStyles, Group, Popover, Table, Text } from '@mantine/core';
+import { ActionIcon, Autocomplete, createStyles, Group, Popover, Table, Text } from '@mantine/core';
 import { useRecoilValue } from 'recoil';
 import { patientTestCaseState } from '../../state/atoms/patientTestCase';
 import { measureBundleState } from '../../state/atoms/measureBundle';
@@ -26,6 +26,7 @@ const useStyles = createStyles({
 
 export interface PopulationComparisonTableProps {
   patientId: string;
+  defIds: Record<string, string>;
 }
 
 export interface DesiredPopulations {
@@ -37,12 +38,14 @@ export interface ResultValues {
   actual: Record<string, number | undefined>;
 }
 
-export default function PopulationComparisonTable({ patientId }: PopulationComparisonTableProps) {
+export default function PopulationComparisonTable({ patientId, defIds }: PopulationComparisonTableProps) {
   const { classes } = useStyles();
   const measureBundle = useRecoilValue(measureBundleState);
   const detailedResultLookup = useRecoilValue(detailedResultLookupState);
   const currentPatients = useRecoilValue(patientTestCaseState);
   const [opened, setOpened] = useState(false);
+  const [searchValue, setSearchValue] = useState<string>('');
+
   const measure = useMemo(() => {
     return measureBundle.content?.entry?.find(e => e.resource?.resourceType === 'Measure')?.resource as fhir4.Measure;
   }, [measureBundle]);
@@ -310,6 +313,15 @@ export default function PopulationComparisonTable({ patientId }: PopulationCompa
             })}
           </tbody>
         </Table>
+        <Autocomplete
+          data={Object.keys(defIds)}
+          value={searchValue}
+          onChange={setSearchValue}
+          label="Search CQL Expression Definition"
+          onItemSubmit={item => {
+            document.getElementById(defIds[item.value])?.scrollIntoView();
+          }}
+        />
       </>
     );
   } else {

--- a/components/calculation/PopulationComparisonTable.tsx
+++ b/components/calculation/PopulationComparisonTable.tsx
@@ -319,7 +319,7 @@ export default function PopulationComparisonTable({ patientId, defIds }: Populat
           onChange={setSearchValue}
           label="Search CQL Expression Definition"
           onItemSubmit={item => {
-            document.getElementById(defIds[item.value])?.scrollIntoView();
+            document.getElementById(defIds[item.value])?.scrollIntoView({ behavior: 'smooth' });
           }}
         />
       </>


### PR DESCRIPTION
# Summary
Add an autocomplete input that scrolls the highlighted cql to the selected expression def

## New Behavior
New autocomplete input under the population results table that scrolls to the input cql expression definition in the highlighted cql

## Code Changes
 - added HTML ids to each define statement (identified by regex) during the parse HTML step
 - added an autocomplete input component
 - updated testing to reflect new components

# Testing Guidance
 - `npm run check`
 - Fire up testify and input a MeasureBundle
 - Create a patient and select it. Ensure that the autocomplete input is populated with all valid expression defs
 - Click on an option and watch it scroll!