### PR TITLE
Custom resource bug fix

### DIFF
--- a/components/resource-creation/ResourcePanel.tsx
+++ b/components/resource-creation/ResourcePanel.tsx
@@ -35,7 +35,9 @@ export default function ResourcePanel() {
       if (!newResource.id) {
         newResource.id = uuidv4();
       }
-      const resourceIndex = currentPatients[selectedPatient].resources.findIndex(r => r.id === newResource.id);
+      const resourceIndex = currentPatients[selectedPatient].resources.findIndex(
+        r => r.resource?.id === newResource.id
+      );
       if (resourceIndex >= 0) {
         showNotification({
           id: 'failed-upload',
@@ -46,7 +48,8 @@ export default function ResourcePanel() {
         });
       } else {
         const nextResourceState = produce(currentPatients, draftState => {
-          draftState[selectedPatient].resources.push(newResource);
+          const entry: fhir4.BundleEntry = { resource: newResource, fullUrl: `urn:uuid:${newResource.id}` };
+          draftState[selectedPatient].resources.push(entry);
         });
         setCurrentPatients(nextResourceState);
         setIsCalculationLoading(true);


### PR DESCRIPTION
# Summary
This PR fixes a small bug in `fqm-testify`. Before, if you created a custom resource, the resource card did not show up in the resource panel nor did the resource when exporting the patient test case. 

## New Behavior
- A bundle entry of the new resource and its associated `fullUrl` are now pushed on the `currentPatients` array to match the updates made in [this PR](https://github.com/projecttacoma/fqm-testify/pull/65).

## Code Changes
- The `resources` property of interface `TestCaseInfo` is now of type `fhir4.BundleEntry[]`, so the code in `ResourcePanel.tsx` was updated to treat it as such rather than a `fhir4.FhirResource[]`.

# Testing Guidance
- `npm run check`
- To replicate the issue on the main branch, do the following:
1. Upload the attached minimal measure bundle (thanks Matt)
2. Create a patient and then a custom resource (I just did one with resourceType Encounter and id "test"
3. Notice that the number of resources above the panel increases, but the info card does not show up.
4. Export the patient test case and see that the resource is also not included there.
- Switch to this branch and try the same thing!
- Try out any other edge cases of creating/deleting custom patients and resources/try to break it.