### PR TITLE
Scrollable panels

### DIFF
--- a/__tests__/components/TestCaseEditor.test.tsx
+++ b/__tests__/components/TestCaseEditor.test.tsx
@@ -3,9 +3,13 @@ import { render, screen } from '@testing-library/react';
 import { RouterContext } from 'next/dist/shared/lib/router-context';
 import TestCaseEditor from '../../components/TestCaseEditor';
 import { selectedPatientState } from '../../state/atoms/selectedPatient';
-import { createMockRouter, getMockRecoilState, mantineRecoilWrap } from '../helpers/testHelpers';
+import { createMockRouter, getMockRecoilState, mantineRecoilWrap, mockResizeObserver } from '../helpers/testHelpers';
 
 describe('TestCaseEditor', () => {
+  beforeAll(() => {
+    window.ResizeObserver = mockResizeObserver;
+  });
+
   it('should render placeholder text with no selected patient', () => {
     const MockSelectedPatient = getMockRecoilState(selectedPatientState, null);
 
@@ -23,5 +27,9 @@ describe('TestCaseEditor', () => {
     // Placeholder text should render in both resource panel and calculation panel
     const placeholderText = screen.getAllByText(/select a patient to add resources/i) as HTMLDivElement[];
     expect(placeholderText).toHaveLength(2);
+  });
+
+  afterAll(() => {
+    jest.clearAllMocks();
   });
 });

--- a/components/TestCaseEditor.tsx
+++ b/components/TestCaseEditor.tsx
@@ -1,4 +1,4 @@
-import { Center, createStyles, Grid, Loader, Stack, Text } from '@mantine/core';
+import { Accordion, Box, Center, createStyles, Grid, Loader, ScrollArea, Space, Text } from '@mantine/core';
 import React from 'react';
 import { useRecoilValue } from 'recoil';
 import { selectedPatientState } from '../state/atoms/selectedPatient';
@@ -9,6 +9,8 @@ import { patientTestCaseState } from '../state/atoms/patientTestCase';
 import { calculationLoading } from '../state/atoms/calculationLoading';
 import { CircleCheck } from 'tabler-icons-react';
 import { getPatientNameString } from '../util/fhir/patient';
+import PopulationComparisonTable from './calculation/PopulationComparisonTable';
+import PopulationComparisonTableControl from './calculation/PopulationComparisonTableControl';
 
 const useStyles = createStyles({
   panel: {
@@ -19,7 +21,7 @@ const useStyles = createStyles({
     maxHeight: '100%'
   },
   highlighting: {
-    maxHeight: 'calc(100% - 50px)',
+    maxHeight: 'calc(100% - 280px)',
     overflow: 'scroll'
   }
 });
@@ -80,7 +82,7 @@ export default function TestCaseEditor() {
           <ResourcePanel />
         </Grid.Col>
         <Grid.Col span={6} className={classes.header} sx={theme => ({ backgroundColor: theme.colors.gray[1] })}>
-          <Stack style={{ height: 50 }}>
+          <Box h={50}>
             {selectedPatient ? (
               <Grid justify="space-between">
                 <Grid.Col span={4}>
@@ -91,10 +93,27 @@ export default function TestCaseEditor() {
             ) : (
               renderPanelPlaceholderText()
             )}
-          </Stack>
-          <Stack className={classes.highlighting}>
+          </Box>
+          <Space />
+          <ScrollArea h={250}>
+            {selectedPatient ? (
+              <Accordion chevronPosition="left" defaultValue="table">
+                <Accordion.Item value="table">
+                  <Accordion.Control>
+                    <PopulationComparisonTableControl />
+                  </Accordion.Control>
+                  <Accordion.Panel>
+                    <PopulationComparisonTable patientId={selectedPatient} />
+                  </Accordion.Panel>
+                </Accordion.Item>
+              </Accordion>
+            ) : (
+              ''
+            )}
+          </ScrollArea>
+          <ScrollArea className={classes.highlighting}>
             {selectedPatient ? <MeasureHighlightingPanel patientId={selectedPatient} /> : ''}
-          </Stack>
+          </ScrollArea>
         </Grid.Col>
       </Grid>
     </>

--- a/components/TestCaseEditor.tsx
+++ b/components/TestCaseEditor.tsx
@@ -1,5 +1,5 @@
 import { Accordion, Box, Center, createStyles, Grid, Loader, ScrollArea, Space, Text } from '@mantine/core';
-import React from 'react';
+import React, { useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import { selectedPatientState } from '../state/atoms/selectedPatient';
 import PatientCreationPanel from './patient-creation/PatientCreationPanel';
@@ -17,11 +17,13 @@ const useStyles = createStyles({
     maxHeight: '100%',
     overflow: 'scroll'
   },
-  header: {
-    maxHeight: '100%'
+  calculation: {
+    maxHeight: '100%',
+    display: 'flex',
+    flexDirection: 'column'
   },
   highlighting: {
-    maxHeight: 'calc(100% - 280px)',
+    flex: 1,
     overflow: 'scroll'
   }
 });
@@ -55,6 +57,7 @@ export default function TestCaseEditor() {
   const selectedPatient = useRecoilValue(selectedPatientState);
   const currentPatients = useRecoilValue(patientTestCaseState);
   const { classes } = useStyles();
+  const [accValue, setAccValue] = useState<string | null>('table');
 
   const renderPanelPlaceholderText = () => {
     return (
@@ -81,7 +84,7 @@ export default function TestCaseEditor() {
         >
           <ResourcePanel />
         </Grid.Col>
-        <Grid.Col span={6} className={classes.header} sx={theme => ({ backgroundColor: theme.colors.gray[1] })}>
+        <Grid.Col span={6} className={classes.calculation} sx={theme => ({ backgroundColor: theme.colors.gray[1] })}>
           <Box h={50}>
             {selectedPatient ? (
               <Grid justify="space-between">
@@ -95,9 +98,9 @@ export default function TestCaseEditor() {
             )}
           </Box>
           <Space />
-          <ScrollArea h={250}>
+          <ScrollArea style={accValue ? { flex: 1 } : {}}>
             {selectedPatient ? (
-              <Accordion chevronPosition="left" defaultValue="table">
+              <Accordion chevronPosition="left" defaultValue="table" value={accValue} onChange={setAccValue}>
                 <Accordion.Item value="table">
                   <Accordion.Control>
                     <PopulationComparisonTableControl />

--- a/components/calculation/MeasureHighlightingPanel.tsx
+++ b/components/calculation/MeasureHighlightingPanel.tsx
@@ -1,12 +1,10 @@
-import { Accordion, Autocomplete, ScrollArea, Space, Text, createStyles } from '@mantine/core';
+import { Autocomplete, ScrollArea, Space, Text, createStyles } from '@mantine/core';
 import { useRecoilValue } from 'recoil';
 import parse from 'html-react-parser';
-import PopulationComparisonTable from './PopulationComparisonTable';
 import { detailedResultLookupState } from '../../state/atoms/detailedResultLookup';
 import { useMemo, useState } from 'react';
 import { Text as DomText } from 'domhandler';
 import { Search } from 'tabler-icons-react';
-import PopulationComparisonTableControl from './PopulationComparisonTableControl';
 
 /**
  * This regex matches any string that includes the substring "define" or "define function"
@@ -32,6 +30,7 @@ export interface MeasureHighlightingPanelProps {
 
 export default function MeasureHighlightingPanel({ patientId }: MeasureHighlightingPanelProps) {
   const { classes } = useStyles();
+  const [searchValue, setSearchValue] = useState('');
   const detailedResultLookup = useRecoilValue(detailedResultLookupState);
   const { parsedHTML, defIds } = useMemo(() => {
     const defIds: Record<string, string> = {};
@@ -50,21 +49,8 @@ export default function MeasureHighlightingPanel({ patientId }: MeasureHighlight
     return { parsedHTML, defIds };
   }, [detailedResultLookup, patientId]);
 
-  // handle search
-  const [searchValue, setSearchValue] = useState('');
-
   return (
     <>
-      <Accordion chevronPosition="left" defaultValue="table">
-        <Accordion.Item value="table">
-          <Accordion.Control>
-            <PopulationComparisonTableControl />
-          </Accordion.Control>
-          <Accordion.Panel>
-            <PopulationComparisonTable patientId={patientId} />
-          </Accordion.Panel>
-        </Accordion.Item>
-      </Accordion>
       <Space h="md" />
       <Autocomplete
         data={Object.keys(defIds).sort((a, b) => (a < b ? -1 : 1))}

--- a/components/calculation/PopulationComparisonTableControl.tsx
+++ b/components/calculation/PopulationComparisonTableControl.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, Group, Popover, Text } from '@mantine/core';
+import { ActionIcon, Group, Popover, ScrollArea, Text } from '@mantine/core';
 import { MouseEvent, useState } from 'react';
 import { InfoCircle } from 'tabler-icons-react';
 import React from 'react';
@@ -26,21 +26,23 @@ export default function PopulationComparisonTableControl() {
             </ActionIcon>
           </Popover.Target>
           <Popover.Dropdown>
-            The Population Comparison Table shows patient and episode population results for the patient selected. For
-            patient-based measures, patient results show 0 or 1 to indicate belonging to a population. Actual and
-            desired populations are compared to highlight cells green if they match and red if they don&apos;t match.
-            <br />
-            <br />
-            For episode-based measures, the table shows patient level totals that indicate how many episodes are in each
-            population. Episode population results show a 0 or 1, and episode observation results show the observed
-            value for that episode.
-            <br />
-            <br />
-            See the{' '}
-            <a href="https://github.com/projecttacoma/fqm-testify#reading-the-population-comparison-table">
-              fqm-testify README
-            </a>{' '}
-            for more information.
+            <ScrollArea h={180}>
+              The Population Comparison Table shows patient and episode population results for the patient selected. For
+              patient-based measures, patient results show 0 or 1 to indicate belonging to a population. Actual and
+              desired populations are compared to highlight cells green if they match and red if they don&apos;t match.
+              <br />
+              <br />
+              For episode-based measures, the table shows patient level totals that indicate how many episodes are in
+              each population. Episode population results show a 0 or 1, and episode observation results show the
+              observed value for that episode.
+              <br />
+              <br />
+              For more information, see the{' '}
+              <a href="https://github.com/projecttacoma/fqm-testify#reading-the-population-comparison-table">
+                fqm-testify README
+              </a>
+              .
+            </ScrollArea>
           </Popover.Dropdown>
         </Popover>
       </div>


### PR DESCRIPTION
# Summary
The population comparison table and the measure highlighting in the right panel of the web application are now in two separate scrollable areas so the user can view them both at the same time.

## New Behavior
- The user can now view the population comparison table while scrolling through the measure highlighting.

## Code Changes
- `TestCaseEditor.tsx` - I put the population comparison table and the measure highlighting in different `ScrollArea`s.
- `MeasureHighlightingPanel.tsx` - Removed the `PopulationComparisonTable` from this file so that they could be in different `ScrollArea`s in `TestCaseEditor.tsx` and added the autocomplete component because we want it to scroll with the highlighting (I think).
- `PopulationComparisonTable.tsx` - Removed the autocomplete component and therefore the `defIds` parameter since it was no longer needed.
- `TestCaseEditor.test.tsx` - I got an error that the `ResizeObserver` was not defined so I just did what we do in other unit tests for `ScrollArea`s and it worked.
- `PopulationComparisonTable.test.tsx` - removed the `defIds parameter.`

# Testing Guidance
- `npm run check`
- `npm run dev`
- Try uploading different measure bundles and patients and see how it looks. Keep in mind that some of this may be improved in another in progress task through collapsible components. 
- Upload the `ratio-Encounter-reuseObservationFunction` measure bundle from the `test/integration` folder of fqm-execution. See how the multiple comparison tables look with scrolling.