### PR TITLE
Collapsible table

### DIFF
--- a/__tests__/components/calculation/PopulationComparisonTable.test.tsx
+++ b/__tests__/components/calculation/PopulationComparisonTable.test.tsx
@@ -158,7 +158,7 @@ describe('PopulationComparisonTable', () => {
             <MockSelectedPatient />
             <MockDetailedResultLookup />
             <Suspense>
-              <PopulationComparisonTable patientId={'example-pt'} defIds={{}} />
+              <PopulationComparisonTable patientId={'example-pt'} />
             </Suspense>
           </>
         )

--- a/components/calculation/MeasureHighlightingPanel.tsx
+++ b/components/calculation/MeasureHighlightingPanel.tsx
@@ -1,11 +1,10 @@
-import { Accordion, Autocomplete, Button, Collapse, ScrollArea, Space, Text, createStyles } from '@mantine/core';
+import { Accordion, Autocomplete, ScrollArea, Space, Text, createStyles } from '@mantine/core';
 import { useRecoilValue } from 'recoil';
 import parse from 'html-react-parser';
 import PopulationComparisonTable, { PopulationComparisonTableControl } from './PopulationComparisonTable';
 import { detailedResultLookupState } from '../../state/atoms/detailedResultLookup';
 import { useMemo, useState } from 'react';
 import { Text as DomText } from 'domhandler';
-import { useDisclosure } from '@mantine/hooks';
 import { Search } from 'tabler-icons-react';
 
 /**

--- a/components/calculation/MeasureHighlightingPanel.tsx
+++ b/components/calculation/MeasureHighlightingPanel.tsx
@@ -1,11 +1,12 @@
 import { Accordion, Autocomplete, ScrollArea, Space, Text, createStyles } from '@mantine/core';
 import { useRecoilValue } from 'recoil';
 import parse from 'html-react-parser';
-import PopulationComparisonTable, { PopulationComparisonTableControl } from './PopulationComparisonTable';
+import PopulationComparisonTable from './PopulationComparisonTable';
 import { detailedResultLookupState } from '../../state/atoms/detailedResultLookup';
 import { useMemo, useState } from 'react';
 import { Text as DomText } from 'domhandler';
 import { Search } from 'tabler-icons-react';
+import PopulationComparisonTableControl from './PopulationComparisonTableControl';
 
 /**
  * This regex matches any string that includes the substring "define" or "define function"

--- a/components/calculation/MeasureHighlightingPanel.tsx
+++ b/components/calculation/MeasureHighlightingPanel.tsx
@@ -1,7 +1,7 @@
-import { Autocomplete, Button, Collapse, ScrollArea, Text, createStyles } from '@mantine/core';
+import { Accordion, Autocomplete, Button, Collapse, ScrollArea, Space, Text, createStyles } from '@mantine/core';
 import { useRecoilValue } from 'recoil';
 import parse from 'html-react-parser';
-import PopulationComparisonTable from './PopulationComparisonTable';
+import PopulationComparisonTable, { PopulationComparisonTableControl } from './PopulationComparisonTable';
 import { detailedResultLookupState } from '../../state/atoms/detailedResultLookup';
 import { useMemo, useState } from 'react';
 import { Text as DomText } from 'domhandler';
@@ -52,16 +52,20 @@ export default function MeasureHighlightingPanel({ patientId }: MeasureHighlight
 
   // handle search
   const [searchValue, setSearchValue] = useState('');
-  
-  // handle collapse
-  const [tableOpened, tableHandlers] = useDisclosure(true);
 
   return (
     <>
-      <Button onClick={tableHandlers.toggle}>Toggle table</Button>
-      <Collapse in={tableOpened}>
-        <PopulationComparisonTable patientId={patientId} defIds={defIds} />
-      </Collapse>
+      <Accordion chevronPosition="left" defaultValue="table">
+        <Accordion.Item value="table">
+          <Accordion.Control>
+            <PopulationComparisonTableControl />
+          </Accordion.Control>
+          <Accordion.Panel>
+            <PopulationComparisonTable patientId={patientId} />
+          </Accordion.Panel>
+        </Accordion.Item>
+      </Accordion>
+      <Space h="md" />
       <Autocomplete
         data={Object.keys(defIds).sort((a, b) => (a < b ? -1 : 1))}
         value={searchValue}

--- a/components/calculation/MeasureHighlightingPanel.tsx
+++ b/components/calculation/MeasureHighlightingPanel.tsx
@@ -1,10 +1,12 @@
-import { createStyles } from '@mantine/core';
+import { Autocomplete, Button, Collapse, ScrollArea, Text, createStyles } from '@mantine/core';
 import { useRecoilValue } from 'recoil';
 import parse from 'html-react-parser';
 import PopulationComparisonTable from './PopulationComparisonTable';
 import { detailedResultLookupState } from '../../state/atoms/detailedResultLookup';
-import { useMemo } from 'react';
-import { Text } from 'domhandler';
+import { useMemo, useState } from 'react';
+import { Text as DomText } from 'domhandler';
+import { useDisclosure } from '@mantine/hooks';
+import { Search } from 'tabler-icons-react';
 
 /**
  * This regex matches any string that includes the substring "define" or "define function"
@@ -36,7 +38,7 @@ export default function MeasureHighlightingPanel({ patientId }: MeasureHighlight
     const parsedHTML = parse(detailedResultLookup[patientId]?.detailedResults?.[0].html || '', {
       replace: elem => {
         if (elem.type === 'text') {
-          const data = (elem as Text).data;
+          const data = (elem as DomText).data;
           if (data.match(expressionDefRegex)) {
             const splitData = data.split('"');
             defIds[splitData[1]] = splitData[1].toLowerCase().replace(' ', '-');
@@ -48,9 +50,37 @@ export default function MeasureHighlightingPanel({ patientId }: MeasureHighlight
     return { parsedHTML, defIds };
   }, [detailedResultLookup, patientId]);
 
+  // handle search
+  const [searchValue, setSearchValue] = useState('');
+  
+  // handle collapse
+  const [tableOpened, tableHandlers] = useDisclosure(true);
+
   return (
     <>
-      <PopulationComparisonTable patientId={patientId} defIds={defIds} />
+      <Button onClick={tableHandlers.toggle}>Toggle table</Button>
+      <Collapse in={tableOpened}>
+        <PopulationComparisonTable patientId={patientId} defIds={defIds} />
+      </Collapse>
+      <Autocomplete
+        data={Object.keys(defIds).sort((a, b) => (a < b ? -1 : 1))}
+        value={searchValue}
+        onChange={setSearchValue}
+        dropdownComponent={ScrollArea}
+        maxDropdownHeight={200}
+        placeholder="Expression Name"
+        icon={<Search />}
+        nothingFound={
+          <Text align="left" style={{ paddingLeft: 10 }}>
+            No Matches
+          </Text>
+        }
+        limit={100}
+        label="Search CQL Expression Definition"
+        onItemSubmit={item => {
+          document.getElementById(defIds[item.value])?.scrollIntoView({ behavior: 'smooth' });
+        }}
+      />
       <div className={classes.highlightedMarkup}>{parsedHTML}</div>
     </>
   );

--- a/components/calculation/PopulationComparisonTable.tsx
+++ b/components/calculation/PopulationComparisonTable.tsx
@@ -24,11 +24,6 @@ const useStyles = createStyles({
   }
 });
 
-export interface PopulationComparisonTableProps {
-  patientId: string;
-  defIds: Record<string, string>;
-}
-
 export interface DesiredPopulations {
   [key: string]: number;
 }
@@ -38,12 +33,11 @@ export interface ResultValues {
   actual: Record<string, number | undefined>;
 }
 
-export default function PopulationComparisonTable({ patientId, defIds }: PopulationComparisonTableProps) {
+export default function PopulationComparisonTable({ patientId }: { patientId: string }) {
   const { classes } = useStyles();
   const measureBundle = useRecoilValue(measureBundleState);
   const detailedResultLookup = useRecoilValue(detailedResultLookupState);
   const currentPatients = useRecoilValue(patientTestCaseState);
-  const [opened, setOpened] = useState(false);
 
   const measure = useMemo(() => {
     return measureBundle.content?.entry?.find(e => e.resource?.resourceType === 'Measure')?.resource as fhir4.Measure;
@@ -263,40 +257,7 @@ export default function PopulationComparisonTable({ patientId, defIds }: Populat
     return (
       <>
         <div />
-        <Group>
-          <div style={{ paddingRight: 5 }}>
-            <Text size="xl" weight={700}>
-              Population Comparison Table
-            </Text>
-          </div>
-          <div>
-            <Popover opened={opened} onClose={() => setOpened(false)} width={500}>
-              <Popover.Target>
-                <ActionIcon aria-label={'More Information'} onClick={() => setOpened(o => !o)}>
-                  <InfoCircle size={20} />
-                </ActionIcon>
-              </Popover.Target>
-              <Popover.Dropdown>
-                The Population Comparison Table shows patient and episode population results for the patient selected.
-                For patient-based measures, patient results show 0 or 1 to indicate belonging to a population. Actual
-                and desired populations are compared to highlight cells green if they match and red if they don&apos;t
-                match.
-                <br />
-                <br />
-                For episode-based measures, the table shows patient level totals that indicate how many episodes are in
-                each population. Episode population results show a 0 or 1, and episode observation results show the
-                observed value for that episode.
-                <br />
-                <br />
-                See the{' '}
-                <a href="https://github.com/projecttacoma/fqm-testify#reading-the-population-comparison-table">
-                  fqm-testify README
-                </a>{' '}
-                for more information.
-              </Popover.Dropdown>
-            </Popover>
-          </div>
-        </Group>
+
         <Table horizontalSpacing="xl">
           <thead>
             <tr>
@@ -317,4 +278,49 @@ export default function PopulationComparisonTable({ patientId, defIds }: Populat
   } else {
     return <Text>Measure highlighting not available</Text>;
   }
+}
+
+export function PopulationComparisonTableControl() {
+  const [opened, setOpened] = useState(false);
+  return (
+    <Group>
+      <div style={{ paddingRight: 5 }}>
+        <Text size="xl" weight={700}>
+          Population Comparison Table
+        </Text>
+      </div>
+      <div>
+        <Popover opened={opened} onClose={() => setOpened(false)} width={500}>
+          <Popover.Target>
+            <ActionIcon
+              aria-label={'More Information'}
+              onClick={e => {
+                e.stopPropagation();
+                setOpened(o => !o);
+              }}
+            >
+              <InfoCircle size={20} />
+            </ActionIcon>
+          </Popover.Target>
+          <Popover.Dropdown>
+            The Population Comparison Table shows patient and episode population results for the patient selected. For
+            patient-based measures, patient results show 0 or 1 to indicate belonging to a population. Actual and
+            desired populations are compared to highlight cells green if they match and red if they don&apos;t match.
+            <br />
+            <br />
+            For episode-based measures, the table shows patient level totals that indicate how many episodes are in each
+            population. Episode population results show a 0 or 1, and episode observation results show the observed
+            value for that episode.
+            <br />
+            <br />
+            See the{' '}
+            <a href="https://github.com/projecttacoma/fqm-testify#reading-the-population-comparison-table">
+              fqm-testify README
+            </a>{' '}
+            for more information.
+          </Popover.Dropdown>
+        </Popover>
+      </div>
+    </Group>
+  );
 }

--- a/components/calculation/PopulationComparisonTable.tsx
+++ b/components/calculation/PopulationComparisonTable.tsx
@@ -1,10 +1,9 @@
-import { ActionIcon, createStyles, Group, Popover, Table, Text } from '@mantine/core';
+import { createStyles, Table, Text } from '@mantine/core';
 import { useRecoilValue } from 'recoil';
 import { patientTestCaseState } from '../../state/atoms/patientTestCase';
 import { measureBundleState } from '../../state/atoms/measureBundle';
-import { MouseEvent, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { getMeasurePopulationsForSelection, MultiSelectData, getPopShorthand } from '../../util/MeasurePopulations';
-import { InfoCircle } from 'tabler-icons-react';
 import { detailedResultLookupState } from '../../state/atoms/detailedResultLookup';
 import { DetailedPopulationGroupResult, PopulationResult } from 'fqm-execution/build/types/Calculator';
 import React from 'react';
@@ -278,49 +277,4 @@ export default function PopulationComparisonTable({ patientId }: { patientId: st
   } else {
     return <Text>Measure highlighting not available</Text>;
   }
-}
-
-export function PopulationComparisonTableControl() {
-  const [opened, setOpened] = useState(false);
-
-  const popoverClick = (e: MouseEvent<HTMLButtonElement>) => {
-    e.stopPropagation();
-    setOpened(o => !o);
-  };
-
-  return (
-    <Group>
-      <div style={{ paddingRight: 5 }}>
-        <Text size="xl" weight={700}>
-          Population Comparison Table
-        </Text>
-      </div>
-      <div>
-        <Popover opened={opened} onClose={() => setOpened(false)} width={500}>
-          <Popover.Target>
-            <ActionIcon aria-label={'More Information'} onClick={popoverClick}>
-              <InfoCircle size={20} />
-            </ActionIcon>
-          </Popover.Target>
-          <Popover.Dropdown>
-            The Population Comparison Table shows patient and episode population results for the patient selected. For
-            patient-based measures, patient results show 0 or 1 to indicate belonging to a population. Actual and
-            desired populations are compared to highlight cells green if they match and red if they don&apos;t match.
-            <br />
-            <br />
-            For episode-based measures, the table shows patient level totals that indicate how many episodes are in each
-            population. Episode population results show a 0 or 1, and episode observation results show the observed
-            value for that episode.
-            <br />
-            <br />
-            See the{' '}
-            <a href="https://github.com/projecttacoma/fqm-testify#reading-the-population-comparison-table">
-              fqm-testify README
-            </a>{' '}
-            for more information.
-          </Popover.Dropdown>
-        </Popover>
-      </div>
-    </Group>
-  );
 }

--- a/components/calculation/PopulationComparisonTable.tsx
+++ b/components/calculation/PopulationComparisonTable.tsx
@@ -2,7 +2,7 @@ import { ActionIcon, createStyles, Group, Popover, Table, Text } from '@mantine/
 import { useRecoilValue } from 'recoil';
 import { patientTestCaseState } from '../../state/atoms/patientTestCase';
 import { measureBundleState } from '../../state/atoms/measureBundle';
-import { useMemo, useState } from 'react';
+import { MouseEvent, useMemo, useState } from 'react';
 import { getMeasurePopulationsForSelection, MultiSelectData, getPopShorthand } from '../../util/MeasurePopulations';
 import { InfoCircle } from 'tabler-icons-react';
 import { detailedResultLookupState } from '../../state/atoms/detailedResultLookup';
@@ -282,6 +282,12 @@ export default function PopulationComparisonTable({ patientId }: { patientId: st
 
 export function PopulationComparisonTableControl() {
   const [opened, setOpened] = useState(false);
+
+  const popoverClick = (e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    setOpened(o => !o);
+  };
+
   return (
     <Group>
       <div style={{ paddingRight: 5 }}>
@@ -292,13 +298,7 @@ export function PopulationComparisonTableControl() {
       <div>
         <Popover opened={opened} onClose={() => setOpened(false)} width={500}>
           <Popover.Target>
-            <ActionIcon
-              aria-label={'More Information'}
-              onClick={e => {
-                e.stopPropagation();
-                setOpened(o => !o);
-              }}
-            >
+            <ActionIcon aria-label={'More Information'} onClick={popoverClick}>
               <InfoCircle size={20} />
             </ActionIcon>
           </Popover.Target>

--- a/components/calculation/PopulationComparisonTable.tsx
+++ b/components/calculation/PopulationComparisonTable.tsx
@@ -1,10 +1,10 @@
-import { ActionIcon, Autocomplete, createStyles, Group, Popover, ScrollArea, Table, Text } from '@mantine/core';
+import { ActionIcon, createStyles, Group, Popover, Table, Text } from '@mantine/core';
 import { useRecoilValue } from 'recoil';
 import { patientTestCaseState } from '../../state/atoms/patientTestCase';
 import { measureBundleState } from '../../state/atoms/measureBundle';
 import { useMemo, useState } from 'react';
 import { getMeasurePopulationsForSelection, MultiSelectData, getPopShorthand } from '../../util/MeasurePopulations';
-import { InfoCircle, Search } from 'tabler-icons-react';
+import { InfoCircle } from 'tabler-icons-react';
 import { detailedResultLookupState } from '../../state/atoms/detailedResultLookup';
 import { DetailedPopulationGroupResult, PopulationResult } from 'fqm-execution/build/types/Calculator';
 import React from 'react';
@@ -44,7 +44,6 @@ export default function PopulationComparisonTable({ patientId, defIds }: Populat
   const detailedResultLookup = useRecoilValue(detailedResultLookupState);
   const currentPatients = useRecoilValue(patientTestCaseState);
   const [opened, setOpened] = useState(false);
-  const [searchValue, setSearchValue] = useState('');
 
   const measure = useMemo(() => {
     return measureBundle.content?.entry?.find(e => e.resource?.resourceType === 'Measure')?.resource as fhir4.Measure;
@@ -313,25 +312,6 @@ export default function PopulationComparisonTable({ patientId, defIds }: Populat
             })}
           </tbody>
         </Table>
-        <Autocomplete
-          data={Object.keys(defIds).sort((a, b) => (a < b ? -1 : 1))}
-          value={searchValue}
-          onChange={setSearchValue}
-          dropdownComponent={ScrollArea}
-          maxDropdownHeight={200}
-          placeholder="Expression Name"
-          icon={<Search />}
-          nothingFound={
-            <Text align="left" style={{ paddingLeft: 10 }}>
-              No Matches
-            </Text>
-          }
-          limit={100}
-          label="Search CQL Expression Definition"
-          onItemSubmit={item => {
-            document.getElementById(defIds[item.value])?.scrollIntoView({ behavior: 'smooth' });
-          }}
-        />
       </>
     );
   } else {

--- a/components/calculation/PopulationComparisonTableControl.tsx
+++ b/components/calculation/PopulationComparisonTableControl.tsx
@@ -1,0 +1,49 @@
+import { ActionIcon, Group, Popover, Text } from '@mantine/core';
+import { MouseEvent, useState } from 'react';
+import { InfoCircle } from 'tabler-icons-react';
+import React from 'react';
+
+export default function PopulationComparisonTableControl() {
+  const [opened, setOpened] = useState(false);
+
+  const popoverClick = (e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    setOpened(o => !o);
+  };
+
+  return (
+    <Group>
+      <div style={{ paddingRight: 5 }}>
+        <Text size="xl" weight={700}>
+          Population Comparison Table
+        </Text>
+      </div>
+      <div>
+        <Popover opened={opened} onClose={() => setOpened(false)} width={500}>
+          <Popover.Target>
+            <ActionIcon aria-label={'More Information'} onClick={popoverClick}>
+              <InfoCircle size={20} />
+            </ActionIcon>
+          </Popover.Target>
+          <Popover.Dropdown>
+            The Population Comparison Table shows patient and episode population results for the patient selected. For
+            patient-based measures, patient results show 0 or 1 to indicate belonging to a population. Actual and
+            desired populations are compared to highlight cells green if they match and red if they don&apos;t match.
+            <br />
+            <br />
+            For episode-based measures, the table shows patient level totals that indicate how many episodes are in each
+            population. Episode population results show a 0 or 1, and episode observation results show the observed
+            value for that episode.
+            <br />
+            <br />
+            See the{' '}
+            <a href="https://github.com/projecttacoma/fqm-testify#reading-the-population-comparison-table">
+              fqm-testify README
+            </a>{' '}
+            for more information.
+          </Popover.Dropdown>
+        </Popover>
+      </div>
+    </Group>
+  );
+}


### PR DESCRIPTION
# Summary
The population comparison table in the measure highlighting panel is collapsible (note: this is an update from the ticket to just collapse the table and not collapse the html markup, based on a conversation in dev hour)

## New Behavior
- The user may click on the population table title area to collapse the table. This uses an accordion style component to help with user-familiar iconography, but the accordion only applies to the one element for now.

## Code Changes
- `PopulationComparisonTable.tsx` - Move clause search to `MeasureHighlightingPanel`, move table title and popover tooltip to their own function so that they can be used as the Accordion control bar, stop popover from clicking through to control bar with updated popoverClick function
- `MeasureHighlightingPanel.tsx` - Add clause search (moved from `PopulationComparisonTable`, use mantine `Accordion` component for collapsible table, use table title and popover as part of accordion control
- `PopulationComparisonTable.test.tsx` - simple change to get rid of an unnecessary pass to the PopulationComparisonTable function component (not needed now that clause search is removed from the table component)

# Testing Guidance
- `npm run check`
- `npm run dev`
- Try uploading different measure bundles and patients and see how it looks. This will also be influenced by scrollable areas once #72 is merged
- Potential suggested test cases: 
  - `CervicalCancerScreeningFHIR-bundle` measure bundle and patients from the ecqm-content-r4 measures. This will create a smaller table.
  - `ratio-Encounter-reuseObservationFunction` measure bundle and patients (especially `patient-3enc-1in-all-2in-denom`) from fqm-execution `test/integration` folder. This will create a larger table.