### PR TITLE
Pretty highlighting

### DIFF
--- a/components/calculation/MeasureHighlightingPanel.tsx
+++ b/components/calculation/MeasureHighlightingPanel.tsx
@@ -31,8 +31,8 @@ export default function MeasureHighlightingPanel({ patientId }: MeasureHighlight
     const parsedHTML = parse(detailedResultLookup[patientId]?.detailedResults?.[0].html || '', {
       replace: elem => {
         if ((elem as DomElement).attribs?.['data-statement-name']) {
-          const statementName = (elem as DomElement).attribs?.['data-statement-name'];
-          const libraryName = (elem as DomElement).attribs?.['data-library-name'];
+          const statementName = (elem as DomElement).attribs['data-statement-name'];
+          const libraryName = (elem as DomElement).attribs['data-library-name'];
           const statementResult = detailedResultLookup[patientId]?.detailedResults?.[0].statementResults.find(
             statement => statement.statementName === statementName && statement.libraryName === libraryName
           );

--- a/components/calculation/MeasureHighlightingPanel.tsx
+++ b/components/calculation/MeasureHighlightingPanel.tsx
@@ -32,8 +32,9 @@ export default function MeasureHighlightingPanel({ patientId }: MeasureHighlight
       replace: elem => {
         if ((elem as DomElement).attribs?.['data-statement-name']) {
           const statementName = (elem as DomElement).attribs?.['data-statement-name'];
+          const libraryName = (elem as DomElement).attribs?.['data-library-name'];
           const statementResult = detailedResultLookup[patientId]?.detailedResults?.[0].statementResults.find(
-            statement => statement.statementName === statementName
+            statement => statement.statementName === statementName && statement.libraryName === libraryName
           );
           return (
             <>

--- a/components/calculation/MeasureHighlightingPanel.tsx
+++ b/components/calculation/MeasureHighlightingPanel.tsx
@@ -73,7 +73,7 @@ export default function MeasureHighlightingPanel({ patientId }: MeasureHighlight
         onItemSubmit={item => {
           document
             .querySelector(
-              `pre[data-statement-name="${item.value.split('"')[1]}"[data-library-name="${item.value.split('"')[0]}"]`
+              `pre[data-statement-name="${item.value.split('"')[1]}"][data-library-name="${item.value.split('.')[0]}"]`
             )
             ?.scrollIntoView({ behavior: 'smooth' });
         }}

--- a/components/calculation/MeasureHighlightingPanel.tsx
+++ b/components/calculation/MeasureHighlightingPanel.tsx
@@ -72,7 +72,9 @@ export default function MeasureHighlightingPanel({ patientId }: MeasureHighlight
         label="Search CQL Expression Definition"
         onItemSubmit={item => {
           document
-            .querySelector(`[data-statement-name="${item.value.split('"')[1]}"`)
+            .querySelector(
+              `pre[data-statement-name="${item.value.split('"')[1]}"[data-library-name="${item.value.split('"')[0]}"]`
+            )
             ?.scrollIntoView({ behavior: 'smooth' });
         }}
         rightSection={

--- a/components/calculation/MeasureHighlightingPanel.tsx
+++ b/components/calculation/MeasureHighlightingPanel.tsx
@@ -1,16 +1,11 @@
-import { Autocomplete, ScrollArea, Space, Text, createStyles } from '@mantine/core';
+import { ActionIcon, Autocomplete, ScrollArea, Space, Text, createStyles } from '@mantine/core';
 import { useRecoilValue } from 'recoil';
-import parse from 'html-react-parser';
+import parse, { domToReact } from 'html-react-parser';
 import { detailedResultLookupState } from '../../state/atoms/detailedResultLookup';
 import { useMemo, useState } from 'react';
-import { Text as DomText } from 'domhandler';
-import { Search } from 'tabler-icons-react';
-
-/**
- * This regex matches any string that includes the substring "define" or "define function"
- * followed by a string of any length in quotes
- */
-const expressionDefRegex = new RegExp(/(define(?:\s+function)?\s+)(["'])(.*?)\2/gi);
+import { Element as DomElement } from 'domhandler';
+import { Search, X } from 'tabler-icons-react';
+import PrettyOutput from './PrettyOutput';
 
 const useStyles = createStyles({
   highlightedMarkup: {
@@ -32,28 +27,35 @@ export default function MeasureHighlightingPanel({ patientId }: MeasureHighlight
   const { classes } = useStyles();
   const [searchValue, setSearchValue] = useState('');
   const detailedResultLookup = useRecoilValue(detailedResultLookupState);
-  const { parsedHTML, defIds } = useMemo(() => {
-    const defIds: Record<string, string> = {};
+  const parsedHTML = useMemo(() => {
     const parsedHTML = parse(detailedResultLookup[patientId]?.detailedResults?.[0].html || '', {
       replace: elem => {
-        if (elem.type === 'text') {
-          const data = (elem as DomText).data;
-          if (data.match(expressionDefRegex)) {
-            const splitData = data.split('"');
-            defIds[splitData[1]] = splitData[1].toLowerCase().replace(' ', '-');
-            return <span id={defIds[splitData[1]]}>{data}</span>;
-          }
+        if ((elem as DomElement).attribs?.['data-statement-name']) {
+          const statementName = (elem as DomElement).attribs?.['data-statement-name'];
+          const statementResult = detailedResultLookup[patientId]?.detailedResults?.[0].statementResults.find(
+            statement => statement.statementName === statementName
+          );
+          return (
+            <>
+              {domToReact([elem])}
+              <PrettyOutput statement={statementResult} />
+            </>
+          );
         }
       }
     });
-    return { parsedHTML, defIds };
+    return parsedHTML;
   }, [detailedResultLookup, patientId]);
 
   return (
     <>
       <Space h="md" />
       <Autocomplete
-        data={Object.keys(defIds).sort((a, b) => (a < b ? -1 : 1))}
+        data={
+          detailedResultLookup[patientId]?.detailedResults?.[0].statementResults
+            .filter(statementResult => statementResult.relevance !== 'NA')
+            .map(s => `${s.libraryName}."${s.statementName}"`) || ['']
+        }
         value={searchValue}
         onChange={setSearchValue}
         dropdownComponent={ScrollArea}
@@ -68,8 +70,19 @@ export default function MeasureHighlightingPanel({ patientId }: MeasureHighlight
         limit={100}
         label="Search CQL Expression Definition"
         onItemSubmit={item => {
-          document.getElementById(defIds[item.value])?.scrollIntoView({ behavior: 'smooth' });
+          document
+            .querySelector(`[data-statement-name="${item.value.split('"')[1]}"`)
+            ?.scrollIntoView({ behavior: 'smooth' });
         }}
+        rightSection={
+          <ActionIcon
+            onClick={() => {
+              setSearchValue('');
+            }}
+          >
+            <X size={16} />
+          </ActionIcon>
+        }
       />
       <div className={classes.highlightedMarkup}>{parsedHTML}</div>
     </>

--- a/components/calculation/PrettyOutput.tsx
+++ b/components/calculation/PrettyOutput.tsx
@@ -12,9 +12,11 @@ export default function PrettyOutput({ statement }: PrettyOutputProps) {
 
   return (
     <>
-      <Button compact variant="outline" color="gray" onClick={toggle}>
-        {buttonText}
-      </Button>
+      <div style={{ width: 120 }}>
+        <Button fullWidth compact variant="outline" color="gray" onClick={toggle}>
+          {buttonText}
+        </Button>
+      </div>
       <Collapse in={opened}>
         <Space />
         <Paper shadow="xs">

--- a/components/calculation/PrettyOutput.tsx
+++ b/components/calculation/PrettyOutput.tsx
@@ -1,4 +1,4 @@
-import { Button, Collapse, Paper, Space } from '@mantine/core';
+import { Button, Collapse, Paper } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { StatementResult } from 'fqm-execution';
 
@@ -12,14 +12,11 @@ export default function PrettyOutput({ statement }: PrettyOutputProps) {
 
   return (
     <>
-      <div style={{ width: 120 }}>
-        <Button fullWidth compact variant="outline" color="gray" onClick={toggle}>
-          {buttonText}
-        </Button>
-      </div>
+      <Button fullWidth compact variant="outline" color="gray" onClick={toggle} w={120}>
+        {buttonText}
+      </Button>
       <Collapse in={opened}>
-        <Space />
-        <Paper shadow="xs">
+        <Paper shadow="xs" pl={8}>
           <pre>{statement?.pretty}</pre>
         </Paper>
       </Collapse>

--- a/components/calculation/PrettyOutput.tsx
+++ b/components/calculation/PrettyOutput.tsx
@@ -1,0 +1,26 @@
+import { Button, Collapse, Paper, Space } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { StatementResult } from 'fqm-execution';
+
+export interface PrettyOutputProps {
+  statement: StatementResult | undefined;
+}
+
+export default function PrettyOutput({ statement }: PrettyOutputProps) {
+  const [opened, { toggle }] = useDisclosure(false);
+  const buttonText = opened ? 'Hide Results' : 'Show Results';
+
+  return (
+    <>
+      <Button compact variant="outline" color="gray" onClick={toggle}>
+        {buttonText}
+      </Button>
+      <Collapse in={opened}>
+        <Space />
+        <Paper shadow="xs">
+          <pre>{statement?.pretty}</pre>
+        </Paper>
+      </Collapse>
+    </>
+  );
+}

--- a/components/calculation/PrettyOutput.tsx
+++ b/components/calculation/PrettyOutput.tsx
@@ -8,12 +8,11 @@ export interface PrettyOutputProps {
 
 export default function PrettyOutput({ statement }: PrettyOutputProps) {
   const [opened, { toggle }] = useDisclosure(false);
-  const buttonText = opened ? 'Hide Results' : 'Show Results';
 
   return (
     <>
       <Button fullWidth compact variant="outline" color="gray" onClick={toggle} w={120}>
-        {buttonText}
+        {opened ? 'Hide Results' : 'Show Results'}
       </Button>
       <Collapse in={opened}>
         <Paper shadow="xs" pl={8}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "dayjs": "^1.11.7",
         "fhirpath": "^2.14.6",
         "file-saver": "^2.0.5",
-        "fqm-execution": "git+https://git@github.com/projecttacoma/fqm-execution",
+        "fqm-execution": "git+https://git@github.com/projecttacoma/fqm-execution.git",
         "immer": "^9.0.14",
         "jszip": "^3.10.0",
         "luxon": "^2.5.2",
@@ -4767,8 +4767,8 @@
       }
     },
     "node_modules/fqm-execution": {
-      "version": "1.1.0",
-      "resolved": "git+https://git@github.com/projecttacoma/fqm-execution.git#34e9c695f89d7823d66ff01e9d912704dcb57384",
+      "version": "1.2.1",
+      "resolved": "git+https://git@github.com/projecttacoma/fqm-execution.git#a369d3a8aaf020fde76646b2bb1fff20cf6d92b4",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/fhir": "0.0.34",
@@ -12534,7 +12534,7 @@
       }
     },
     "fqm-execution": {
-      "version": "git+https://git@github.com/projecttacoma/fqm-execution.git#34e9c695f89d7823d66ff01e9d912704dcb57384",
+      "version": "git+https://git@github.com/projecttacoma/fqm-execution.git#a369d3a8aaf020fde76646b2bb1fff20cf6d92b4",
       "from": "fqm-execution@git+https://git@github.com/projecttacoma/fqm-execution",
       "requires": {
         "@types/fhir": "0.0.34",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12535,7 +12535,7 @@
     },
     "fqm-execution": {
       "version": "git+https://git@github.com/projecttacoma/fqm-execution.git#a369d3a8aaf020fde76646b2bb1fff20cf6d92b4",
-      "from": "fqm-execution@git+https://git@github.com/projecttacoma/fqm-execution",
+      "from": "fqm-execution@git+https://git@github.com/projecttacoma/fqm-execution.git",
       "requires": {
         "@types/fhir": "0.0.34",
         "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "dayjs": "^1.11.7",
     "fhirpath": "^2.14.6",
     "file-saver": "^2.0.5",
-    "fqm-execution": "git+https://git@github.com/projecttacoma/fqm-execution",
+    "fqm-execution": "git+https://git@github.com/projecttacoma/fqm-execution.git",
     "immer": "^9.0.14",
     "jszip": "^3.10.0",
     "luxon": "^2.5.2",


### PR DESCRIPTION
# Summary
This PR adds rendering of pretty statement results in the measure highlighting panel.

## New Behavior
Each statement result in the `MeasureHighlightingPanel` now has a button below it that says "Show Results". When the user clicks on this button, a collapsible component is opened that contains the pre-formatted pretty statement results. The `Autocomplete` component behaves the same way, it was just updated to utilize the `data-statement-name` in the html rather than a defined Regular Expression.

## Code Changes
- `MeasureHighlightingPanel.tsx` - Parses through the html and inserts a `PrettyOutput` component below each statement result in the measure logic highlighting. It also updates the `Autocomplete` component to use `data-statement-name` rather than the Regular Expression and the `defIds` record. The `Autocomplete` data attribute is populated with all of the statement named in the statement results that have relevance !== null (so either TRUE or FALSE) because these are the statements that are rendered in the highlighting.
- `PrettyOutput.tsx` - New component that consists of a Button and a collapsible component that contains the statement result pretty output.

# Testing Guidance
- `npm run check`
- `npm run dev`
- Upload a measure and check out a patient's measure highlighting panel. Test the buttons, make sure the pretty results are correct, let me know if you have any styling suggestions!