### PR TITLE
sort out next v14 export and pages build issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [20.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,7 +7,7 @@ name: Deploy Next.js site to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["main"]
+    branches: ['main']
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -20,7 +20,7 @@ permissions:
 
 # Allow one concurrent deployment
 concurrency:
-  group: "pages"
+  group: 'pages'
   cancel-in-progress: true
 
 jobs:
@@ -50,7 +50,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: "18"
+          node-version: '20'
           cache: ${{ steps.detect-package-manager.outputs.manager }}
       - name: Setup Pages
         uses: actions/configure-pages@v2
@@ -86,8 +86,8 @@ jobs:
 
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:
-      pages: write      # to deploy to Pages
-      id-token: write   # to verify the deployment originates from an appropriate source
+      pages: write # to deploy to Pages
+      id-token: write # to verify the deployment originates from an appropriate source
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Once calculation has finished, the user can access an HTML representation of the
 
 ## License
 
-Copyright 2022 The MITRE Corporation
+Copyright 2023 The MITRE Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  output: 'export',
   reactStrictMode: true,
   eslint: {
     dirs: ['pages', 'utils', 'lib', 'components', 'atoms', '__tests__', 'scripts']

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:codes": "ts-node scripts/parseCodePath.ts && prettier --write util/codePaths.ts --loglevel silent",
     "build:names": "ts-node scripts/generatePatientNames.ts && prettier --write data/names.ts --loglevel silent",
     "build:lookups": "npm run build:codes && npm run build:names && npm run build:dates",
-    "start": "next start",
+    "start": "npx serve@latest out",
     "lint": "next lint && tsc --noEmit",
     "lint:fix": "next lint --fix",
     "prettier": "prettier --check \"**/*.{js,ts,jsx,tsx,css}\"",


### PR DESCRIPTION
# Summary

Update to use node 20 for build. Switch next output to `export`. Reconfigure `start` command to use Vercel's `serve`.

## New Behavior

## Code Changes

# Testing Guidance