### PR TITLE
Change package to cqfm.package

### DIFF
--- a/components/measure-upload/MeasureRepositoryUpload.tsx
+++ b/components/measure-upload/MeasureRepositoryUpload.tsx
@@ -149,7 +149,7 @@ export default function MeasureRepositoryUpload({ logError }: MeasureUploadProps
   }
 
   /**
-   * Sends a `POST` request to the `Measure/:id/$package` endpoint of the specified Measure
+   * Sends a `POST` request to the `Measure/:id/$cqfm.package` endpoint of the specified Measure
    * Repository Service. Checks the resulting bundle is valid and saves it if so.
    */
   async function retrieveMeasurePackage(id: string) {
@@ -163,7 +163,7 @@ export default function MeasureRepositoryUpload({ logError }: MeasureUploadProps
         color: 'blue'
       });
       setIsLoadingPackage(PACKAGE_STATES.LOADING);
-      const response = await fetch(`${measureRepositoryUrl}/Measure/${id}/$package`, MEASURE_RETRIEVAL_OPTIONS);
+      const response = await fetch(`${measureRepositoryUrl}/Measure/${id}/$cqfm.package`, MEASURE_RETRIEVAL_OPTIONS);
       const responseBody: fhir4.Bundle | fhir4.OperationOutcome = await response.json();
       if (responseBody.resourceType !== 'Bundle') {
         if (responseBody.resourceType === 'OperationOutcome') {

--- a/components/utils/MeasureRespositoryUploadHeader.tsx
+++ b/components/utils/MeasureRespositoryUploadHeader.tsx
@@ -30,8 +30,8 @@ export default function MeasureRepositoryUploadHeader() {
             </Text>
             <Text>
               The server must support the{' '}
-              <Anchor href="https://build.fhir.org/ig/HL7/cqf-measures/measure-repository-service.html#package">
-                $package
+              <Anchor href="https://build.fhir.org/ig/HL7/cqf-measures/OperationDefinition-cqfm-package.html">
+                $cqfm.package
               </Anchor>{' '}
               operation for Measure resources with the &quot;include-terminology&quot; parameter.
             </Text>


### PR DESCRIPTION
# Summary
This PR changes the call to the MRS for Measure Repository Service Bundle upload from the old `$package` endpoint to the new `$cqfm.package` endpoint.

## New Behavior
We are now able to properly upload a Measure Bundle from the latest version of our Measure Repository and have it be properly packaged using `$cqfm.package`.

## Code Changes
- Changes any references to `$package` to `$cqfm.package`.

# Testing Guidance
- `npm run check`
- `PORT=8080 npm run dev` (just diff port than local MRS instance running)
- Load the MRS with some measure bundles (preferably ones in our coverage script bundles directory)
- `npm run start:all`
- Pull up fqm-testify at http://localhost:8080
- Input http://localhost:3000/4_0_1 to the Measure Repository Service URL input
- Make sure the dropdown is populated with active Measures in the MRS
- Click one of the measures and make sure there are no errors with packaging 

Note: we did test this together in dev hour