### PR TITLE
Add a Delete All Patients button

### DIFF
--- a/__tests__/components/patient-creation/PatientCreationPanel.test.tsx
+++ b/__tests__/components/patient-creation/PatientCreationPanel.test.tsx
@@ -154,6 +154,47 @@ describe('PatientCreationPanel', () => {
     expect(testPatientMetaProfile).toBeInTheDocument();
   });
 
+  it('should render confirmation modal when delete all patients button is clicked', async () => {
+    const MockMB = getMockRecoilState(measureBundleState, MEASURE_BUNDLE_POPULATED);
+    const MockPatients = getMockRecoilState(patientTestCaseState, {
+      'example-pt': {
+        patient: {
+          resourceType: 'Patient',
+          name: [{ given: ['Test123'], family: 'Patient456' }]
+        },
+        fullUrl: 'urn:uuid:testPatient',
+        resources: [],
+        minResources: false
+      }
+    });
+
+    await act(async () => {
+      render(
+        mantineRecoilWrap(
+          <>
+            <MockMB />
+            <MockPatients />
+            <Suspense>
+              <RouterContext.Provider value={createMockRouter({ pathname: '/' })}>
+                <PatientCreationPanel />
+              </RouterContext.Provider>
+            </Suspense>
+          </>
+        )
+      );
+    });
+
+    const deleteAllButton = screen.getByLabelText(/delete all patients/i) as HTMLButtonElement;
+    expect(deleteAllButton).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(deleteAllButton);
+    });
+
+    const confirmationModal = screen.getByRole('dialog', { hidden: true });
+    expect(confirmationModal).toBeInTheDocument();
+  });
+
   it('should not render test case list with empty state', async () => {
     const MockPatients = getMockRecoilState(patientTestCaseState, {});
 

--- a/components/patient-creation/PatientCreationPanel.tsx
+++ b/components/patient-creation/PatientCreationPanel.tsx
@@ -184,7 +184,6 @@ function PatientCreationPanel() {
   };
 
   const closeConfirmationModal = () => {
-    setPatientsToDelete([]);
     setIsConfirmationModalOpen(false);
   };
 
@@ -201,8 +200,9 @@ function PatientCreationPanel() {
     });
     setCurrentPatients(nextPatientState);
     setDetailedResultLookup(nextResourceState);
-    // Set the selected patient to null because the selected patient will not longer exist after it is deleted
+    // Set the selected patient to null because the selected patient will no longer exist after it is deleted
     setSelectedPatient(null);
+    setPatientsToDelete([]);
     closeConfirmationModal();
   };
 
@@ -460,7 +460,7 @@ function PatientCreationPanel() {
           aria-label="Delete All Patients"
           disabled={Object.keys(currentPatients).length === 0}
           onClick={() => {
-            setPatientsToDelete(Object.keys(currentPatients).map(cp => cp));
+            setPatientsToDelete(Object.keys(currentPatients));
             openConfirmationModal();
           }}
           variant="outline"


### PR DESCRIPTION
# Summary
This PR adds a "Delete All Patients" button in the PatientCreationPanel.

## New Behavior
The user can now delete all patients in the PatientCreationPanel with one button rather than going through each patient.

## Code Changes
- `PatientCreationPanel.tsx` - added `isDeleteAll` state variable so that the Confirmation Modal text can be easily adjusted for the new button (is there a better way to do this so I can still reuse that Confirmation Modal?), add `deleteAllPatients` to remove all patients and their resources
- `PatientCreationPanel.test.tsx` - associated unit test

# Testing Guidance
- `npm run check`
- `npm run dev`
- Make sure the app has the desired behavior
- Looking for feedback on the UI and button placement- see slack thread for details!