### PR TITLE
Use statement-level HTML for Measure Highlighting

### DIFF
--- a/components/calculation/MeasureHighlightingPanel.tsx
+++ b/components/calculation/MeasureHighlightingPanel.tsx
@@ -34,10 +34,10 @@ export default function MeasureHighlightingPanel({ dr }: MeasureHighlightingPane
     return relevantStatements.map(sr => {
       if (sr.statementLevelHTML) {
         return (
-          <>
+          <div key={`${dr.groupId}-${sr.libraryName}-${sr.statementName}`}>
             {parse(sr.statementLevelHTML)}
             <PrettyOutput statement={sr} />
-          </>
+          </div>
         );
       }
     });

--- a/components/calculation/MeasureHighlightingPanel.tsx
+++ b/components/calculation/MeasureHighlightingPanel.tsx
@@ -1,10 +1,12 @@
 import { ActionIcon, Autocomplete, ScrollArea, Space, Text, createStyles } from '@mantine/core';
-import parse, { domToReact } from 'html-react-parser';
-import { useState } from 'react';
-import { Element as DomElement } from 'domhandler';
+import parse from 'html-react-parser';
+import { useMemo, useState } from 'react';
 import { Search, X } from 'tabler-icons-react';
 import PrettyOutput from './PrettyOutput';
-import { DetailedPopulationGroupResult } from 'fqm-execution';
+import { DetailedPopulationGroupResult, Relevance } from 'fqm-execution';
+import { useRecoilValue } from 'recoil';
+import { measureBundleState } from '../../state/atoms/measureBundle';
+import { sortStatements } from '../../util/MeasurePopulations';
 
 const useStyles = createStyles({
   highlightedMarkup: {
@@ -21,24 +23,25 @@ export interface MeasureHighlightingPanelProps {
 export default function MeasureHighlightingPanel({ dr }: MeasureHighlightingPanelProps) {
   const { classes } = useStyles();
   const [searchValue, setSearchValue] = useState('');
+  const measureBundle = useRecoilValue(measureBundleState);
+  const measure = useMemo(() => {
+    return measureBundle.content?.entry?.find(e => e.resource?.resourceType === 'Measure')?.resource as fhir4.Measure;
+  }, [measureBundle]);
 
-  const parsedHTML = parse(dr.html || '', {
-    replace: elem => {
-      if ((elem as DomElement).attribs?.['data-statement-name']) {
-        const statementName = (elem as DomElement).attribs['data-statement-name'];
-        const libraryName = (elem as DomElement).attribs['data-library-name'];
-        const statementResult = dr.statementResults.find(
-          statement => statement.statementName === statementName && statement.libraryName === libraryName
-        );
+  const parsedHTML = () => {
+    const relevantStatements = dr.statementResults.filter(s => s.relevance !== Relevance.NA);
+    sortStatements(measure, dr.groupId, relevantStatements);
+    return relevantStatements.map(sr => {
+      if (sr.statementLevelHTML) {
         return (
           <>
-            {domToReact([elem])}
-            <PrettyOutput statement={statementResult} />
+            {parse(sr.statementLevelHTML)}
+            <PrettyOutput statement={sr} />
           </>
         );
       }
-    }
-  });
+    });
+  };
 
   return (
     <>
@@ -79,7 +82,10 @@ export default function MeasureHighlightingPanel({ dr }: MeasureHighlightingPane
           </ActionIcon>
         }
       />
-      <div className={classes.highlightedMarkup}>{parsedHTML}</div>
+      <div className={classes.highlightedMarkup}>
+        <h2>Population Group: {dr.groupId}</h2>
+        {parsedHTML()}
+      </div>
     </>
   );
 }

--- a/util/MeasureCalculation.ts
+++ b/util/MeasureCalculation.ts
@@ -22,7 +22,8 @@ export async function calculateDetailedResult(
     measurementPeriodStart: mpStart,
     measurementPeriodEnd: mpEnd,
     useElmJsonsCaching: true,
-    trustMetaProfile: trustMetaProfile
+    trustMetaProfile: trustMetaProfile,
+    buildStatementLevelHTML: true
   };
 
   const patientBundle = createPatientBundle(patientTestCase.patient, patientTestCase.resources);


### PR DESCRIPTION
# Summary
This PR finally updates `fqm-testify` to use `buildStatementLevelHTML: true` in CalculationOptions so we can use `statementResult.statementLevelHTML` for the MeasureHighlightingPanel rather than parsing through the entire `DetailedPopulationGroupResult.html`.

## New Behavior
- There should be no new behavior observed in the app.

## Code Changes
- `components/calculation/MeasureHighlightingPanel.tsx` - `parsedHTML` now goes through the dr.statementResults, filters only the relevantStatements, and sorts them (this was all done in the regular `generateHTML` function in `fqm-execution` so this was all already done before when we parsed the overall html.
- `util/MeasureCalculation.ts` - add `buildStatementLevelHTML: true` to `calculateDetailedResult` calculationOptions
- `util/MeasurePopulations.ts` - added `sortStatements()` function (see question about this below

# Testing Guidance
- `npm run check`
- `npm run dev`
- Make sure the `MeasureHighlightingPanel.tsx` has the same functionality- CQL statement search still works, the statement result is still in the drop down below each statement, population groupId is still displayed, etc.

# Questions
- I had to pull that `sortStatements` function from fqm-execution, should I make a backlog task to perhaps have that function exported from fqm-execution so we don't need to add the whole function to this repository?