### PR TITLE
Small fixes

### DIFF
--- a/components/resource-creation/ResourceDisplay.tsx
+++ b/components/resource-creation/ResourceDisplay.tsx
@@ -241,11 +241,16 @@ function ResourceDisplay() {
       // Sort
       if (cardFilters.sortType) {
         filtered.sort((a, b) => {
-          if (!a.resource || !b.resource) return 0;
+          // set no resource as "higher" values
+          if (!a.resource) return b.resource ? 1 : 0;
+          if (!b.resource) return -1;
           if (cardFilters.sortType === 'date') {
-            const dateA = dateForResource(a.resource).date.toLowerCase();
-            const dateB = dateForResource(b.resource).date.toLowerCase();
-            return cardFilters.sortOrder === 'asc' ? dateA.localeCompare(dateB) : dateB.localeCompare(dateA);
+            const dateA = dateForResource(a.resource).sortDate?.getTime();
+            const dateB = dateForResource(b.resource).sortDate?.getTime();
+            // set no sortDate resource as "higher" values
+            if (!dateA) return dateB ? 1 : 0;
+            if (!dateB) return -1;
+            return cardFilters.sortOrder === 'asc' ? dateA - dateB : dateB - dateA;
           }
           if (cardFilters.sortType === 'resourceType') {
             const typeA = a.resource.resourceType.toLowerCase();

--- a/util/fhir/codes.ts
+++ b/util/fhir/codes.ts
@@ -108,20 +108,38 @@ export function getResourceCode(resource: any, dr: fhir4.DataRequirement, mb: fh
  */
 export function getFhirResourceSummary(resource: fhir4.Resource) {
   let primaryCodePath = parsedCodePaths[resource.resourceType]?.primaryCodePath;
+  let pathEval;
+  // handle choice type
+  if (primaryCodePath) {
+    const pathInfo = parsedCodePaths[resource.resourceType].paths[primaryCodePath];
+    if (pathInfo?.choiceType) {
+      primaryCodePath = `${primaryCodePath}${pathInfo.codeType.replace('FHIR.', '')}`;
+    }
 
-  if (fhirpath.evaluate(resource, `${primaryCodePath}.coding`)[0] === undefined) {
+    console.log(`code type ${pathInfo?.codeType}`);
+    if (pathInfo?.codeType === 'FHIR.CodeableConcept') {
+      pathEval = fhirpath.evaluate(resource, `${primaryCodePath}.coding`)[0] as fhir4.Coding;
+    } else if (pathInfo?.codeType === 'FHIR.Coding') {
+      pathEval = fhirpath.evaluate(resource, primaryCodePath)[0] as fhir4.Coding;
+    } else if (pathInfo?.codeType === 'FHIR.code') {
+      pathEval = fhirpath.evaluate(resource, primaryCodePath)[0] as string;
+    }
+  }
+
+  // backup case finds first available coding
+  if (pathEval === undefined) {
     const paths = parsedCodePaths[resource.resourceType]?.paths;
     for (const p in paths) {
       if (fhirpath.evaluate(resource, `${p}.coding`)[0]) {
         primaryCodePath = p;
       }
     }
+    pathEval = fhirpath.evaluate(resource, `${primaryCodePath}.coding`)[0] as string;
   }
 
-  if (primaryCodePath) {
-    const primaryCoding = fhirpath.evaluate(resource, `${primaryCodePath}.coding`)[0];
-    const resourceCode = primaryCoding?.code;
-    const resourceDisplay = primaryCoding?.display;
+  if (pathEval) {
+    const resourceCode = typeof pathEval === 'string' ? pathEval : pathEval.code;
+    const resourceDisplay = typeof pathEval === 'string' ? undefined : pathEval.display;
 
     if (resourceCode && resourceDisplay) {
       return `(${resourceCode}: ${resourceDisplay})`;

--- a/util/fhir/codes.ts
+++ b/util/fhir/codes.ts
@@ -115,8 +115,7 @@ export function getFhirResourceSummary(resource: fhir4.Resource) {
     if (pathInfo?.choiceType) {
       primaryCodePath = `${primaryCodePath}${pathInfo.codeType.replace('FHIR.', '')}`;
     }
-
-    console.log(`code type ${pathInfo?.codeType}`);
+    
     if (pathInfo?.codeType === 'FHIR.CodeableConcept') {
       pathEval = fhirpath.evaluate(resource, `${primaryCodePath}.coding`)[0] as fhir4.Coding;
     } else if (pathInfo?.codeType === 'FHIR.Coding') {

--- a/util/fhir/codes.ts
+++ b/util/fhir/codes.ts
@@ -115,7 +115,7 @@ export function getFhirResourceSummary(resource: fhir4.Resource) {
     if (pathInfo?.choiceType) {
       primaryCodePath = `${primaryCodePath}${pathInfo.codeType.replace('FHIR.', '')}`;
     }
-    
+
     if (pathInfo?.codeType === 'FHIR.CodeableConcept') {
       pathEval = fhirpath.evaluate(resource, `${primaryCodePath}.coding`)[0] as fhir4.Coding;
     } else if (pathInfo?.codeType === 'FHIR.Coding') {

--- a/util/fhir/dates.ts
+++ b/util/fhir/dates.ts
@@ -13,6 +13,12 @@ export interface DateInfo {
   [dateField: string]: DateFieldInfo;
 }
 
+export interface DateFormatInfo {
+  date: string;
+  dateType: string;
+  sortDate?: Date;
+}
+
 /**
  * Parses the primary date path info and populates date info to satisfy date filter specified in the passed-in data requirement
  * @param {Object} resource FHIR resource being created
@@ -166,18 +172,17 @@ export function getRandomPeriodInPeriod(start: string, end: string): fhir4.Perio
 }
 
 /**
- * Takes in resource and returns the Date and dateType formatted nicely (used in Resource Display cards)
+ * Takes in resource and returns the date and dateType, formatted nicely (used in Resource Display cards), and sortDate (used for sorting).
+ * If primary date is a period, date will be in format mm/dd/yyyy-mm/dd/yyyy, and sortDate is set to start (if available) by default
  * @param {fhir4.FhirResource} resource resource to have date formatted
- * @param {string} end end date string for the period
- * @returns {Object} two strings  {date, dateType} if date is a period it will be in the format of mm/dd/yyyy-mm/dd/yyyy
+ * @returns {Object} primary date formatting strings and sorting date
  */
-export function dateForResource(resource: fhir4.FhirResource) {
+export function dateForResource(resource: fhir4.FhirResource): DateFormatInfo {
   const dateInfo = PrimaryDatePaths.parsedPrimaryDatePaths[resource.resourceType];
   if (!resource || !PrimaryDatePaths?.parsedPrimaryDatePaths || !dateInfo) {
     return {
       date: 'N/A',
-      dateType: 'N/A',
-      sortDate: undefined
+      dateType: 'N/A'
     };
   }
 
@@ -222,8 +227,7 @@ export function dateForResource(resource: fhir4.FhirResource) {
   }
   return {
     date: 'N/A',
-    dateType: 'N/A',
-    sortDate: undefined
+    dateType: 'N/A'
   };
 }
 

--- a/util/fhir/dates.ts
+++ b/util/fhir/dates.ts
@@ -166,17 +166,18 @@ export function getRandomPeriodInPeriod(start: string, end: string): fhir4.Perio
 }
 
 /**
- * Takes in resource and returns the Date and dateType formatted nicley (used in Resource Display cards)
+ * Takes in resource and returns the Date and dateType formatted nicely (used in Resource Display cards)
  * @param {fhir4.FhirResource} resource resource to have date formatted
  * @param {string} end end date string for the period
  * @returns {Object} two strings  {date, dateType} if date is a period it will be in the format of mm/dd/yyyy-mm/dd/yyyy
  */
-export function dateForResource(resource: fhir4.FhirResource): any {
+export function dateForResource(resource: fhir4.FhirResource) {
   const dateInfo = PrimaryDatePaths.parsedPrimaryDatePaths[resource.resourceType];
   if (!resource || !PrimaryDatePaths?.parsedPrimaryDatePaths || !dateInfo) {
     return {
       date: 'N/A',
-      dateType: 'N/A'
+      dateType: 'N/A',
+      sortDate: undefined
     };
   }
 
@@ -192,7 +193,8 @@ export function dateForResource(resource: fhir4.FhirResource): any {
       else {
         return {
           date: formatDate(fhirpath.evaluate(resource, nameOfResourceDate)[0]),
-          dateType: nameOfResourceDate
+          dateType: nameOfResourceDate,
+          sortDate: new Date(fhirpath.evaluate(resource, nameOfResourceDate)[0])
         };
       }
     }
@@ -210,7 +212,8 @@ export function dateForResource(resource: fhir4.FhirResource): any {
           else {
             return {
               date: formatDate(fhirpath.evaluate(resource, fullResourceDateName)[0]),
-              dateType: fullResourceDateName
+              dateType: fullResourceDateName,
+              sortDate: new Date(fhirpath.evaluate(resource, fullResourceDateName)[0])
             };
           }
         }
@@ -219,7 +222,8 @@ export function dateForResource(resource: fhir4.FhirResource): any {
   }
   return {
     date: 'N/A',
-    dateType: 'N/A'
+    dateType: 'N/A',
+    sortDate: undefined
   };
 }
 
@@ -229,7 +233,8 @@ const formatPeriod = (resource: fhir4.FhirResource, resourcePeriod: string, date
   const endTime = fhirpath.evaluate(resource, resourcePeriod + '.end')[0];
   return {
     date: formatDate(startTime) + '-' + formatDate(endTime),
-    dateType: dateTypeName
+    dateType: dateTypeName,
+    sortDate: startTime ? new Date(startTime) : new Date(endTime)
   };
 };
 


### PR DESCRIPTION
# Summary
Some useful changes for handling resource viewing. Updates the resource summary to properly use certain characteristics of the primary date path. Update sorting by date to use the date comparison instead of string comparison.

## New Behavior
Resource cards work better for choice type primary paths (i.e. MedicationRequest) and non-CodeableConcept primary paths (i.e. MessageDefinition, OperationDefinition)

## Code Changes

- `dates.ts` - adds a Date-typed `sortDate` field to the returned object in `dateForResource`
- `ResourceDisplay.tsx` - uses the `sortDate` to sort resources by date
- `code.ts` - fully utilizes the path information from the `parsedCodePaths` to handle choice types and alternate code types

# Testing Guidance

- `npm run check`
- `npm run dev`
- Test with a patient with many resources of different dates to make sure date sorting (asc and desc) is done correctly. Create a resource without a date to make sure it is sorted last.
- Test with or create your own MedicationRequest, MessageDefinition, and OperationDefinition resources to make sure that the code from the primary code path are shown for each in the resource info card.