### PR TITLE
Fix time components of measurement period start and end

### DIFF
--- a/components/calculation/PopulationCalculation.tsx
+++ b/components/calculation/PopulationCalculation.tsx
@@ -4,7 +4,7 @@ import { Calculator, CalculatorTypes } from 'fqm-execution';
 import { patientTestCaseState } from '../../state/atoms/patientTestCase';
 import { measureBundleState } from '../../state/atoms/measureBundle';
 import { useState } from 'react';
-import { measurementPeriodState } from '../../state/atoms/measurementPeriod';
+import { measurementPeriodFormattedState } from '../../state/atoms/measurementPeriod';
 import { showNotification } from '@mantine/notifications';
 import { IconAlertCircle } from '@tabler/icons';
 import { getPatientInfoString } from '../../util/fhir/patient';
@@ -19,7 +19,7 @@ export default function PopulationCalculation() {
 
   const currentPatients = useRecoilValue(patientTestCaseState);
   const measureBundle = useRecoilValue(measureBundleState);
-  const measurementPeriod = useRecoilValue(measurementPeriodState);
+  const measurementPeriodFormatted = useRecoilValue(measurementPeriodFormattedState);
   const [detailedResults, setDetailedResults] = useState<LabeledDetailedResult[]>([]);
   const [opened, setOpened] = useState(false);
   const [enableTableButton, setEnableTableButton] = useState(false);
@@ -53,8 +53,8 @@ export default function PopulationCalculation() {
       calculateClauseCoverage: true,
       calculateClauseUncoverage: true,
       reportType: 'individual',
-      measurementPeriodStart: measurementPeriod.start?.toISOString(),
-      measurementPeriodEnd: measurementPeriod.end?.toISOString(),
+      measurementPeriodStart: measurementPeriodFormatted?.start,
+      measurementPeriodEnd: measurementPeriodFormatted?.end,
       trustMetaProfile: trustMetaProfile
     };
 

--- a/components/patient-creation/PatientCreationPanel.tsx
+++ b/components/patient-creation/PatientCreationPanel.tsx
@@ -5,7 +5,7 @@ import produce from 'immer';
 import CodeEditorModal from '../modals/CodeEditorModal';
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import { patientTestCaseState, TestCaseInfo } from '../../state/atoms/patientTestCase';
-import { measurementPeriodState } from '../../state/atoms/measurementPeriod';
+import { measurementPeriodFormattedState, measurementPeriodState } from '../../state/atoms/measurementPeriod';
 import { selectedPatientState } from '../../state/atoms/selectedPatient';
 import React, { ReactNode, useMemo, useState } from 'react';
 import { download } from '../../util/downloadUtil';
@@ -55,6 +55,7 @@ function PatientCreationPanel() {
   const [selectedPatient, setSelectedPatient] = useRecoilState(selectedPatientState);
   const measureBundle = useRecoilValue(measureBundleState);
   const measurementPeriod = useRecoilValue(measurementPeriodState);
+  const measurementPeriodFormatted = useRecoilValue(measurementPeriodFormattedState);
   const setIsCalculationLoading = useSetRecoilState(calculationLoading);
   const [detailedResultLookup, setDetailedResultLookup] = useRecoilState(detailedResultLookupState);
   const isSmallScreen = useMediaQuery('(max-width: 1600px)');
@@ -98,8 +99,8 @@ function PatientCreationPanel() {
             draftState[id] = await calculateDetailedResult(
               currentPatients[id],
               measureBundle.content,
-              measurementPeriod.start?.toISOString(),
-              measurementPeriod.end?.toISOString(),
+              measurementPeriodFormatted?.start,
+              measurementPeriodFormatted?.end,
               trustMetaProfile
             );
           } catch (error) {
@@ -154,8 +155,8 @@ function PatientCreationPanel() {
               draftState[patientId] = await calculateDetailedResult(
                 nextPatientState[patientId],
                 measureBundle.content,
-                measurementPeriod.start?.toISOString(),
-                measurementPeriod.end?.toISOString(),
+                measurementPeriodFormatted?.start,
+                measurementPeriodFormatted?.end,
                 trustMetaProfile
               );
             } catch (error) {

--- a/components/resource-creation/ResourceDisplay.tsx
+++ b/components/resource-creation/ResourceDisplay.tsx
@@ -8,7 +8,7 @@ import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import { calculationLoading } from '../../state/atoms/calculationLoading';
 import { detailedResultLookupState } from '../../state/atoms/detailedResultLookup';
 import { measureBundleState } from '../../state/atoms/measureBundle';
-import { measurementPeriodState } from '../../state/atoms/measurementPeriod';
+import { measurementPeriodFormattedState, measurementPeriodState } from '../../state/atoms/measurementPeriod';
 import { cardFiltersAtom } from '../../state/atoms/cardFilters';
 import { patientTestCaseState, TestCase } from '../../state/atoms/patientTestCase';
 import { selectedDataRequirementState } from '../../state/atoms/selectedDataRequirement';
@@ -23,6 +23,7 @@ import CodeEditorModal from '../modals/CodeEditorModal';
 import ConfirmationModal from '../modals/ConfirmationModal';
 import ResourceInfoCard from '../utils/ResourceInfoCard';
 import ResourceSearchSort from './ResourceSearchSort';
+import React from 'react';
 
 function ResourceDisplay() {
   const [currentTestCases, setCurrentTestCases] = useRecoilState(patientTestCaseState);
@@ -32,6 +33,7 @@ function ResourceDisplay() {
   const measureBundle = useRecoilValue(measureBundleState);
   const selectedPatient = useRecoilValue(selectedPatientState);
   const measurementPeriod = useRecoilValue(measurementPeriodState);
+  const measurementPeriodFormatted = useRecoilValue(measurementPeriodFormattedState);
   const [isConfirmationModalOpen, setIsConfirmationModalOpen] = useState(false);
   const setIsCalculationLoading = useSetRecoilState(calculationLoading);
   const [detailedResultLookup, setDetailedResultLookup] = useRecoilState(detailedResultLookupState);
@@ -99,8 +101,8 @@ function ResourceDisplay() {
         draftState[selectedPatient] = await calculateDetailedResult(
           nextResourceState[selectedPatient],
           measureBundle.content,
-          measurementPeriod.start?.toISOString(),
-          measurementPeriod.end?.toISOString(),
+          measurementPeriodFormatted?.start,
+          measurementPeriodFormatted?.end,
           trustMetaProfile
         );
       } catch (error) {

--- a/components/resource-creation/ResourceDisplay.tsx
+++ b/components/resource-creation/ResourceDisplay.tsx
@@ -23,7 +23,6 @@ import CodeEditorModal from '../modals/CodeEditorModal';
 import ConfirmationModal from '../modals/ConfirmationModal';
 import ResourceInfoCard from '../utils/ResourceInfoCard';
 import ResourceSearchSort from './ResourceSearchSort';
-import React from 'react';
 
 function ResourceDisplay() {
   const [currentTestCases, setCurrentTestCases] = useRecoilState(patientTestCaseState);

--- a/components/resource-creation/ResourcePanel.tsx
+++ b/components/resource-creation/ResourcePanel.tsx
@@ -13,7 +13,7 @@ import ResourceSelection from './ResourceSelection';
 import { showNotification } from '@mantine/notifications';
 import { calculationLoading } from '../../state/atoms/calculationLoading';
 import { measureBundleState } from '../../state/atoms/measureBundle';
-import { measurementPeriodState } from '../../state/atoms/measurementPeriod';
+import { measurementPeriodFormattedState } from '../../state/atoms/measurementPeriod';
 import { getPatientNameString } from '../../util/fhir/patient';
 import { detailedResultLookupState } from '../../state/atoms/detailedResultLookup';
 import { calculateDetailedResult } from '../../util/MeasureCalculation';
@@ -25,7 +25,7 @@ export default function ResourcePanel() {
   const [isNewResourceModalOpen, setIsNewResourceModalOpen] = useState(false);
   const setIsCalculationLoading = useSetRecoilState(calculationLoading);
   const measureBundle = useRecoilValue(measureBundleState);
-  const measurementPeriod = useRecoilValue(measurementPeriodState);
+  const measurementPeriodFormatted = useRecoilValue(measurementPeriodFormattedState);
   const [detailedResultLookup, setDetailedResultLookup] = useRecoilState(detailedResultLookupState);
   const trustMetaProfile = useRecoilValue(trustMetaProfileState);
   const [minimizeResourcesPopoverOpened, setMinimizeResourcesPopoverOpened] = useState(false);
@@ -64,8 +64,8 @@ export default function ResourcePanel() {
                 draftState[selectedPatient] = await calculateDetailedResult(
                   nextResourceState[selectedPatient],
                   measureBundle.content,
-                  measurementPeriod.start?.toISOString(),
-                  measurementPeriod.end?.toISOString(),
+                  measurementPeriodFormatted?.start,
+                  measurementPeriodFormatted?.end,
                   trustMetaProfile
                 );
               } catch (error) {

--- a/pages/generate-test-cases.tsx
+++ b/pages/generate-test-cases.tsx
@@ -4,7 +4,7 @@ import React, { useEffect } from 'react';
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import TestCaseEditor from '../components/TestCaseEditor';
 import { measureBundleState } from '../state/atoms/measureBundle';
-import { measurementPeriodState } from '../state/atoms/measurementPeriod';
+import { measurementPeriodFormattedState } from '../state/atoms/measurementPeriod';
 import type { NextPage } from 'next';
 import { patientTestCaseState } from '../state/atoms/patientTestCase';
 import produce from 'immer';
@@ -16,7 +16,7 @@ import { calculateDetailedResult } from '../util/MeasureCalculation';
 import { trustMetaProfileState } from '../state/atoms/trustMetaProfile';
 
 const TestCaseEditorPage: NextPage = () => {
-  const { start, end } = useRecoilValue(measurementPeriodState);
+  const measurementPeriodFormatted = useRecoilValue(measurementPeriodFormattedState);
   const measureBundle = useRecoilValue(measureBundleState);
   const currentPatients = useRecoilValue(patientTestCaseState);
   const setIsCalculationLoading = useSetRecoilState(calculationLoading);
@@ -34,8 +34,8 @@ const TestCaseEditorPage: NextPage = () => {
             draftState[patientId] = await calculateDetailedResult(
               testCaseInfo,
               mb,
-              start?.toISOString(),
-              end?.toISOString(),
+              measurementPeriodFormatted?.start,
+              measurementPeriodFormatted?.end,
               trustMetaProfile
             );
           } catch (error) {
@@ -62,7 +62,7 @@ const TestCaseEditorPage: NextPage = () => {
   return (
     <>
       <div>
-        {start && end && measureBundle.content ? (
+        {measurementPeriodFormatted && measureBundle.content ? (
           <TestCaseEditor />
         ) : (
           <Center sx={() => ({ flexDirection: 'column' })}>

--- a/state/atoms/measurementPeriod.ts
+++ b/state/atoms/measurementPeriod.ts
@@ -17,3 +17,26 @@ export const measurementPeriodState = selector<{ start: Date | null; end: Date |
     end: get(measurementPeriodEndState)
   })
 });
+
+/**
+ * Selector for the start and end date normalized to 00:00:00.000Z and 23:59:59.999Z
+ */
+export const measurementPeriodFormattedState = selector<{ start: string; end: string } | null>({
+  key: 'measurementPeriodFormattedState',
+  get: ({ get }) => {
+    const startDate = get(measurementPeriodStartState);
+    const endDate = get(measurementPeriodEndState);
+    if (startDate && endDate) {
+      const fixedStart = new Date(startDate);
+      fixedStart.setUTCHours(0, 0, 0, 0);
+      const fixedEnd = new Date(endDate);
+      fixedEnd.setUTCHours(23, 59, 59, 999);
+      return {
+        start: fixedStart.toISOString(),
+        end: fixedEnd.toISOString()
+      };
+    } else {
+      return null;
+    }
+  }
+});

--- a/util/MeasureCalculation.ts
+++ b/util/MeasureCalculation.ts
@@ -26,6 +26,7 @@ export async function calculateDetailedResult(
     buildStatementLevelHTML: true
   };
 
+  console.log(options);
   const patientBundle = createPatientBundle(patientTestCase.patient, patientTestCase.resources);
 
   const { results } = await Calculator.calculate(mb, [patientBundle], options);

--- a/util/MeasureCalculation.ts
+++ b/util/MeasureCalculation.ts
@@ -26,7 +26,6 @@ export async function calculateDetailedResult(
     buildStatementLevelHTML: true
   };
 
-  console.log(options);
   const patientBundle = createPatientBundle(patientTestCase.patient, patientTestCase.resources);
 
   const { results } = await Calculator.calculate(mb, [patientBundle], options);


### PR DESCRIPTION
# Summary

Fixes time components of measurement period. These were defaulting to the hour of the local timezone offset (ex. 5AM for ET) on both the start and end. This fixes the start to be at 00:00:00.000Z and end to be at 23:59:59.999Z for the given days.

## New Behavior

Adds a new Recoil selector `measurementPeriodFormattedState`. If both start and end atoms are set it will be an object which has ISO strings for the dates with the time components configured.

## Code Changes

- `state/atoms/measurementPeriod.ts` - New selector addition.
- Various components - all components that call out to fqm-e for calculation now make use of the new selector for the options given to the calculator.

# Testing Guidance

Create a test case which hits something that tests something being in the measurement period. Have the date being compared set in that final few hours of the measurement period. Alternatively use test data provided on slack.