### PR TITLE
Initial totals and coloring

### DIFF
--- a/components/calculation/PopulationResultsTable.tsx
+++ b/components/calculation/PopulationResultsTable.tsx
@@ -1,8 +1,9 @@
-import { createStyles, Table } from '@mantine/core';
+import { Badge, createStyles, Table } from '@mantine/core';
 import { useMemo } from 'react';
 import { DetailedResult } from '../../util/types';
 import { useRecoilValue } from 'recoil';
 import { patientTestCaseState } from '../../state/atoms/patientTestCase';
+import { IconCheck, IconX } from '@tabler/icons';
 
 const useStyles = createStyles({
   highlightRed: {
@@ -100,16 +101,35 @@ export default function PopulationResultTable({ results }: PopulationResultViewe
         {populationResult.label[1] === undefined ? (
           <td>{populationResult.label[0]}</td>
         ) : (
-          <td className={populationResult.label[1] ? classes.highlightGreen : classes.highlightRed}>
+          <td>
+            {populationResult.label[1] ? (
+              <Badge
+                color="green"
+                style={{
+                  marginRight: '5px'
+                }}
+              >
+                <IconCheck />
+              </Badge>
+            ) : (
+              <Badge
+                color="red"
+                style={{
+                  marginRight: '5px'
+                }}
+              >
+                <IconX />
+              </Badge>
+            )}
             {populationResult.label[0]}
           </td>
         )}
 
         {tableHeaders.map(e =>
-          populationResult[e][1] === undefined ? (
+          populationResult[e][1] === undefined || populationResult[e][1] ? (
             <td key={e}>{populationResult[e][0]}</td>
           ) : (
-            <td className={populationResult[e][1] ? classes.highlightGreen : classes.highlightRed} key={e}>
+            <td className={classes.highlightRed} key={e}>
               {populationResult[e][0]}
             </td>
           )

--- a/components/calculation/PopulationResultsTable.tsx
+++ b/components/calculation/PopulationResultsTable.tsx
@@ -63,7 +63,7 @@ export default function PopulationResultTable({ results }: PopulationResultViewe
   }
 
   /**
-   * Strips population results off of a DetailedResult and calls PopulationResultsRow to format them into a TSX component
+   * Strips population results off of a DetailedResult and gives back info on results and whether they match desired
    */
   function extractPopulationResultInfo(dr: DetailedResult, label = 'Unlabeled Patient') {
     const group = dr.detailedResults?.[0];
@@ -76,10 +76,14 @@ export default function PopulationResultTable({ results }: PopulationResultViewe
           currentPatients[dr.patientId].desiredPopulations === undefined
             ? undefined
             : pr.result === currentPatients[dr.patientId].desiredPopulations?.includes(pr.populationType);
-        if (!matchesDesired) {
-          // falsify patient label (not a total match)
+        if (matchesDesired === undefined) {
+          // don't highlight label if there isn't a result
+          labeledPopulationResults.label[1] = undefined;
+        } else if (!matchesDesired) {
+          // falsify patient label if not a total match
           labeledPopulationResults.label[1] = false;
         }
+
         labeledPopulationResults[key as string] = [pr.result ? 1 : 0, matchesDesired];
       }
     });

--- a/components/calculation/PopulationResultsTable.tsx
+++ b/components/calculation/PopulationResultsTable.tsx
@@ -1,6 +1,23 @@
-import { Table } from '@mantine/core';
+import { createStyles, Table } from '@mantine/core';
 import { useMemo } from 'react';
 import { DetailedResult } from '../../util/types';
+import { useRecoilValue } from 'recoil';
+import { patientTestCaseState } from '../../state/atoms/patientTestCase';
+
+const useStyles = createStyles({
+  highlightRed: {
+    backgroundColor: '#edd8d0',
+    color: '#a63b12',
+    borderBottomColor: '#a63b12',
+    borderBottomStyle: 'double'
+  },
+  highlightGreen: {
+    backgroundColor: '#ccebe0',
+    color: '#20744c',
+    borderBottomColor: '#20744c',
+    borderBottomStyle: 'solid'
+  }
+});
 
 export type PopulationResultViewerProps = {
   results: LabeledDetailedResult[];
@@ -11,50 +28,88 @@ export type LabeledDetailedResult = {
   detailedResult: DetailedResult;
 };
 
-export type PopulationResult = Record<string, string | number> & { label: string };
+// Mapping of population key to a value and boolean expressing whether the value matches expected
+// intersected with a label value (patient name) and boolean used to express whether all values match
+export type PopulationValue = Record<string, [string | number, boolean | undefined]> & {
+  label: [string, boolean | undefined];
+};
 
 export default function PopulationResultTable({ results }: PopulationResultViewerProps) {
   const tableHeaders = useMemo(() => {
     return extractTableHeaders(results?.[0].detailedResult);
   }, [results]);
+  const currentPatients = useRecoilValue(patientTestCaseState);
+  const { classes } = useStyles();
 
   /**
    * Converts an array of DetailedResults with labels into JSX table rows for display
    */
   function constructPopulationResultsArray(results: LabeledDetailedResult[]) {
-    return results
+    const allInfo = results
       .filter(drInfo => drInfo.detailedResult)
       .map(drInfo => {
-        return extractPopulationResultRow(drInfo.detailedResult, drInfo.label);
+        return extractPopulationResultInfo(drInfo.detailedResult, drInfo.label);
       });
+    const totalsRow = (
+      <tr key="totals">
+        <td>Totals</td>
+        {tableHeaders.map(e => (
+          <td key={e}>{allInfo.reduce((acc, current) => acc + (current[e][0] as number), 0)}</td>
+        ))}
+      </tr>
+    );
+    const allRows = [totalsRow, ...allInfo.map(info => PopulationResultsRow(info))];
+    return allRows;
   }
 
   /**
    * Strips population results off of a DetailedResult and calls PopulationResultsRow to format them into a TSX component
    */
-  function extractPopulationResultRow(dr: DetailedResult, label = 'Unlabeled Patient') {
+  function extractPopulationResultInfo(dr: DetailedResult, label = 'Unlabeled Patient') {
     const group = dr.detailedResults?.[0];
-    const labeledPopulationResults = { label };
-    group?.populationResults?.reduce((acc: PopulationResult, e) => {
-      const key = e.criteriaExpression || e.populationType;
+    const labeledPopulationResults: PopulationValue = { label: [label, true] }; // initially assume total match
+
+    group?.populationResults?.forEach(pr => {
+      const key = pr.criteriaExpression || pr.populationType;
       if (key) {
-        acc[key as string] = e.result === true ? 1 : 0;
+        const matchesDesired =
+          currentPatients[dr.patientId].desiredPopulations === undefined
+            ? undefined
+            : pr.result === currentPatients[dr.patientId].desiredPopulations?.includes(pr.populationType);
+        if (!matchesDesired) {
+          // falsify patient label (not a total match)
+          labeledPopulationResults.label[1] = false;
+        }
+        labeledPopulationResults[key as string] = [pr.result ? 1 : 0, matchesDesired];
       }
-      return acc;
-    }, labeledPopulationResults);
-    return PopulationResultsRow(labeledPopulationResults);
+    });
+
+    return labeledPopulationResults;
   }
 
   /**
    * Formats population results for a FHIR Patient into a TSX component for display as a table row
    */
-  function PopulationResultsRow(populationResult: PopulationResult) {
+  function PopulationResultsRow(populationResult: PopulationValue) {
     return (
-      <tr key={populationResult.label}>
-        <td>{populationResult.label}</td>
-        {tableHeaders.map(e => (
-          <td key={e}>{populationResult[e]}</td>
-        ))}
+      <tr key={populationResult.label[0]}>
+        {populationResult.label[1] === undefined ? (
+          <td>{populationResult.label[0]}</td>
+        ) : (
+          <td className={populationResult.label[1] ? classes.highlightGreen : classes.highlightRed}>
+            {populationResult.label[0]}
+          </td>
+        )}
+
+        {tableHeaders.map(e =>
+          populationResult[e][1] === undefined ? (
+            <td key={e}>{populationResult[e][0]}</td>
+          ) : (
+            <td className={populationResult[e][1] ? classes.highlightGreen : classes.highlightRed} key={e}>
+              {populationResult[e][0]}
+            </td>
+          )
+        )}
       </tr>
     );
   }


### PR DESCRIPTION
# Summary
Adds a total across all patients for the population counts screen as well as red/green highlighting for whether a  population value matches the expected value.
There are a couple of small design points on this, but this is probably the most expedient approach. Interested in whether we think this meets the need well.

## New Behavior
When the user shows the table of population results, the table shows totals (first row of the table) and red/green highlighting against desired populations.

## Code Changes

- Changes within the PopulationResultsTable.tsx file to total all results and color individual cells.

# Testing Guidance

- `npm run check`
- `npm run dev`
- Load a measure and test cases, click "Calculate Population Results", and look at the table. Experiment with creating new test cases or loading other test cases.