### PR TITLE
Data mr

### DIFF
--- a/__tests__/components/calculation/PopulationCalculation.test.tsx
+++ b/__tests__/components/calculation/PopulationCalculation.test.tsx
@@ -28,46 +28,58 @@ const MOCK_BUNDLE: fhir4.Bundle = {
 };
 
 describe('PopulationCalculation', () => {
-  it('should not render Calculate Population Results button by default', () => {
-    render(
-      mantineRecoilWrap(
-        <>
-          <RouterContext.Provider value={createMockRouter({ pathname: '/' })}>
-            <PopulationCalculation />
-          </RouterContext.Provider>
-        </>
-      )
-    );
+  it('should not render Calculate Population Results button by default', async () => {
+    await act(async () => {
+      render(
+        mantineRecoilWrap(
+          <>
+            <Suspense>
+              <RouterContext.Provider value={createMockRouter({ pathname: '/' })}>
+                <PopulationCalculation />
+              </RouterContext.Provider>
+            </Suspense>
+          </>
+        )
+      );
+    });
 
     const calculateButton = screen.queryByTestId('calculate-all-button');
     expect(calculateButton).not.toBeInTheDocument();
   });
 
-  it('should not render Show Table button by default', () => {
-    render(
-      mantineRecoilWrap(
-        <>
-          <RouterContext.Provider value={createMockRouter({ pathname: '/' })}>
-            <PopulationCalculation />
-          </RouterContext.Provider>
-        </>
-      )
-    );
+  it('should not render Show Table button by default', async () => {
+    await act(async () => {
+      render(
+        mantineRecoilWrap(
+          <>
+            <Suspense>
+              <RouterContext.Provider value={createMockRouter({ pathname: '/' })}>
+                <PopulationCalculation />
+              </RouterContext.Provider>
+            </Suspense>
+          </>
+        )
+      );
+    });
 
     const showTableButton = screen.queryByTestId('show-table-button');
     expect(showTableButton).not.toBeInTheDocument();
   });
 
-  it('should not render Show Clause Coverage button by default', () => {
-    render(
-      mantineRecoilWrap(
-        <>
-          <RouterContext.Provider value={createMockRouter({ pathname: '/' })}>
-            <PopulationCalculation />
-          </RouterContext.Provider>
-        </>
-      )
-    );
+  it('should not render Show Clause Coverage button by default', async () => {
+    await act(async () => {
+      render(
+        mantineRecoilWrap(
+          <>
+            <Suspense>
+              <RouterContext.Provider value={createMockRouter({ pathname: '/' })}>
+                <PopulationCalculation />
+              </RouterContext.Provider>
+            </Suspense>
+          </>
+        )
+      );
+    });
 
     const showClauseCoverageButton = screen.queryByTestId('show-coverage-button');
     expect(showClauseCoverageButton).not.toBeInTheDocument();

--- a/__tests__/components/calculation/PopulationCalculation.test.tsx
+++ b/__tests__/components/calculation/PopulationCalculation.test.tsx
@@ -8,6 +8,7 @@ import { Calculator } from 'fqm-execution';
 import MeasureUpload from '../../../components/measure-upload/MeasureFileUpload';
 import { DetailedResult } from '../../../util/types';
 import { RouterContext } from 'next/dist/shared/lib/router-context.shared-runtime';
+import { Suspense } from 'react';
 
 const MOCK_DETAILED_RESULT: DetailedResult = {
   patientId: '',
@@ -72,7 +73,7 @@ describe('PopulationCalculation', () => {
     expect(showClauseCoverageButton).not.toBeInTheDocument();
   });
 
-  it('should render Calculate Population Results button when measure bundle is present and at least one patient created', () => {
+  it('should render Calculate Population Results button when measure bundle is present and at least one patient created', async () => {
     const MockMB = getMockRecoilState(measureBundleState, {
       fileName: 'testName',
       content: MOCK_BUNDLE,
@@ -93,17 +94,29 @@ describe('PopulationCalculation', () => {
       }
     });
 
-    render(
-      mantineRecoilWrap(
-        <>
-          <MockMB />
-          <MockPatients />
-          <RouterContext.Provider value={createMockRouter({ pathname: '/' })}>
-            <PopulationCalculation />
-          </RouterContext.Provider>
-        </>
-      )
-    );
+    jest.spyOn(Calculator, 'calculateDataRequirements').mockResolvedValue({
+      results: {
+        resourceType: 'Library',
+        status: 'draft',
+        type: {}
+      }
+    });
+
+    await act(async () => {
+      render(
+        mantineRecoilWrap(
+          <>
+            <MockMB />
+            <MockPatients />
+            <Suspense>
+              <RouterContext.Provider value={createMockRouter({ pathname: '/' })}>
+                <PopulationCalculation />
+              </RouterContext.Provider>
+            </Suspense>
+          </>
+        )
+      );
+    });
 
     const calculateButton = screen.getByRole('button', { name: 'Calculate Population Results' }) as HTMLButtonElement;
     expect(calculateButton).toBeInTheDocument();
@@ -161,9 +174,11 @@ describe('PopulationCalculation', () => {
             <MockPatients />
             <MockMB />
             <MeasureUpload logError={jest.fn()} />
-            <RouterContext.Provider value={createMockRouter({ pathname: '/' })}>
-              <PopulationCalculation />
-            </RouterContext.Provider>
+            <Suspense>
+              <RouterContext.Provider value={createMockRouter({ pathname: '/' })}>
+                <PopulationCalculation />
+              </RouterContext.Provider>
+            </Suspense>
           </>
         )
       );
@@ -234,9 +249,11 @@ describe('PopulationCalculation', () => {
             <MockPatients />
             <MockMB />
             <MeasureUpload logError={jest.fn()} />
-            <RouterContext.Provider value={createMockRouter({ pathname: '/' })}>
-              <PopulationCalculation />
-            </RouterContext.Provider>
+            <Suspense>
+              <RouterContext.Provider value={createMockRouter({ pathname: '/' })}>
+                <PopulationCalculation />
+              </RouterContext.Provider>
+            </Suspense>
           </>
         )
       );
@@ -307,9 +324,11 @@ describe('PopulationCalculation', () => {
             <MockPatients />
             <MockMB />
             <MeasureUpload logError={jest.fn()} />
-            <RouterContext.Provider value={createMockRouter({ pathname: '/' })}>
-              <PopulationCalculation />
-            </RouterContext.Provider>
+            <Suspense>
+              <RouterContext.Provider value={createMockRouter({ pathname: '/' })}>
+                <PopulationCalculation />
+              </RouterContext.Provider>
+            </Suspense>
           </>
         )
       );

--- a/components/calculation/PopulationCalculation.tsx
+++ b/components/calculation/PopulationCalculation.tsx
@@ -80,7 +80,7 @@ export default function PopulationCalculation() {
           title: 'Patient data submission failed',
           message: `Submitting data for Patient: ${getPatientNameString(
             currentPatients[id].patient
-          )} failed with message: "${responseBody.issue[0].details?.text}"`,
+          )} failed with details: "${responseBody.issue[0].details?.text ?? response.status}"`,
           color: 'red'
         });
         return;

--- a/components/calculation/PopulationCalculation.tsx
+++ b/components/calculation/PopulationCalculation.tsx
@@ -53,7 +53,7 @@ export default function PopulationCalculation() {
    * without using Measure/$deqm-submit-data endpoint
    * Each transaction bundle should contain DEQM Data Exchange MeasureReports with data-of-interest
    * and should be for a single subject (will do a separate POST for each patient)
-   * @returns { string[] } the evaluation service ids for POSTed patients (may be different than sent IDs or undefined if send was unsuccessful)
+   * @returns { string|undefined[] } the evaluation service ids for POSTed patients (may be different than sent IDs or undefined if send was unsuccessful)
    */
   const submitDataToEvaluationService = async (): Promise<(string | undefined)[]> => {
     // collect data and POST to evaluation service (TODO: should be $submit-data when available)
@@ -73,17 +73,6 @@ export default function PopulationCalculation() {
         body: JSON.stringify(bundle),
         headers: { 'Content-Type': 'application/json+fhir' }
       });
-      if (!response.ok) {
-        showNotification({
-          icon: <IconAlertCircle />,
-          title: 'Evaluation service failure',
-          message: `Submitting data for Patient: ${getPatientNameString(
-            currentPatients[id].patient
-          )} failed with code ${response.status}`,
-          color: 'red'
-        });
-        return;
-      }
       const responseBody: fhir4.Bundle | fhir4.OperationOutcome = await response.json();
       if (responseBody.resourceType === 'OperationOutcome') {
         showNotification({
@@ -113,11 +102,11 @@ export default function PopulationCalculation() {
     submitDataToEvaluationService()
       .then(postedIds => {
         const resolvedIds = postedIds?.filter(id => id !== undefined);
-        if (resolvedIds) {
+        if (resolvedIds.length > 0) {
           showNotification({
             icon: <IconCircleCheck />,
             title: 'Successfully sent data',
-            message: `Successfully sent data for ${resolvedIds.length} patients for measure ${evaluationMeasureId}`, //TODO: update to canonical, currently using evaluationMeasureId here whereas it will be used for $submitdata in the future
+            message: `Successfully sent data for ${resolvedIds.length} patients for measure ${evaluationMeasureId}`, //TODO: update to canonical, currently using evaluationMeasureId here whereas it will be used for $submit-data in the future
             color: 'green'
           });
           // TODO: use resolvedIds to populate evaluate modal


### PR DESCRIPTION
# Summary
A poor man's $submit-data...

Note: This is currently based off of the branch here: https://github.com/projecttacoma/fqm-testify/pull/109 and will be rebased once that PR is merged

## New Behavior
Adds a submit data button which collates minimum data resources for each patient, adds a data exchange measure report for each (in accordance with https://build.fhir.org/ig/HL7/davinci-deqm/StructureDefinition-datax-measurereport-deqm.html), POSTs that data to the stored evaluation service URL, and enables an evaluate button (currently a stub that opens an empty modal). 
The goal is for this to closely reflect a client's use of [$submit-data](https://build.fhir.org/ig/HL7/davinci-deqm/OperationDefinition-submit-data.html) but without actually using the submit data operation.

## Code Changes

- Update `resourceCreation.ts` util to add `createDataExchangeMeasureReport` function
- Update `PopulationCalculation.tsx` to add two buttons, modal, and functions to do data submission
- Update tests to handle added `dataRequirementsLookupByType` async selector 

NOTE: many TODOs have been left in to give direction for what to change when this becomes a proper $submit-data as well as a TODO for the evaluate implementation and a TODO for a measure report decision that needs to be verified with server systems at the connectathon.

# Testing Guidance

- `npm run check`
- Check the deqm-test-server base `/Patient` endpoint to see how many patients there are
- `npm run dev`
- Upload to fqm-testify a measure that exists on the internal deployment of the deqm-test-server. (I can share a measure and test cases if needed)
- Add the deqm-test-server base as the evaluation service url
- On the next page, upload test cases.
- Scroll to the bottom of the test case list and click "Submit Data" -> should give a success notification and enable the "Evaluate" button
- Check the deqm-test-server base `/Patient` endpoint again to see if patient number has increased by number of test cases. (Note: patient number will only increase if test cases aren't already on the server.) If you want to test again with the same test case(s), change the patient id for those test cases.