### PR TITLE
Evaluate button

### DIFF
--- a/components/calculation/PopulationCalculation.tsx
+++ b/components/calculation/PopulationCalculation.tsx
@@ -134,7 +134,9 @@ export default function PopulationCalculation() {
           });
           setSubjectData(
             resolvedIds.map(idObj => {
-              return { value: idObj.postedId, label: getPatientNameString(idObj.testCaseInfo.patient) };
+              return idObj
+                ? { value: idObj.postedId, label: getPatientNameString(idObj.testCaseInfo.patient) }
+                : { value: '', label: '' };
             })
           );
           setEnableEvaluateButton(true);

--- a/components/calculation/PopulationCalculation.tsx
+++ b/components/calculation/PopulationCalculation.tsx
@@ -171,11 +171,11 @@ export default function PopulationCalculation() {
         },
         {
           name: 'periodStart',
-          valueString: measurementPeriodFormatted?.start
+          valueString: measurementPeriodFormatted?.start.split('T')[0]
         },
         {
           name: 'periodEnd',
-          valueString: measurementPeriodFormatted?.end
+          valueString: measurementPeriodFormatted?.end.split('T')[0]
         },
         {
           name: 'reportType',

--- a/components/calculation/PopulationCalculation.tsx
+++ b/components/calculation/PopulationCalculation.tsx
@@ -170,7 +170,7 @@ export default function PopulationCalculation() {
         }
       ]
     };
-    if (reportTypeValue === 'individual' && subjectValue) {
+    if (reportTypeValue === 'subject' && subjectValue) {
       parameters.parameter?.push({
         name: 'subject',
         valueString: `Patient/${subjectValue}`
@@ -181,21 +181,12 @@ export default function PopulationCalculation() {
       body: JSON.stringify(parameters),
       headers: { 'Content-Type': 'application/json+fhir' }
     });
-    if (!response.ok) {
-      showNotification({
-        icon: <IconAlertCircle />,
-        title: 'Evaluation service failure',
-        message: `Evaluation call failed with code ${response.status}`,
-        color: 'red'
-      });
-      return;
-    }
     const responseBody: fhir4.Bundle | fhir4.OperationOutcome = await response.json();
     if (responseBody.resourceType === 'OperationOutcome') {
       showNotification({
         icon: <IconAlertCircle />,
         title: 'Evaluation operation failed',
-        message: `Evaluation call failed with message: "${responseBody.issue[0].details?.text}"`,
+        message: `Evaluation call failed with details: "${responseBody.issue[0].details?.text ?? response.status}"`,
         color: 'red'
       });
       return;

--- a/components/calculation/PopulationCalculation.tsx
+++ b/components/calculation/PopulationCalculation.tsx
@@ -161,7 +161,8 @@ export default function PopulationCalculation() {
       });
   };
 
-  const sendEvaluate = async (): Promise<fhir4.Bundle | undefined> => {
+  // TODO: should be constrained to Parameters in the future
+  const sendEvaluate = async (): Promise<fhir4.Bundle | fhir4.Parameters | undefined> => {
     const parameters: fhir4.Parameters = {
       resourceType: 'Parameters',
       parameter: [
@@ -171,11 +172,11 @@ export default function PopulationCalculation() {
         },
         {
           name: 'periodStart',
-          valueString: measurementPeriodFormatted?.start.split('T')[0]
+          valueDate: measurementPeriodFormatted?.start.split('T')[0]
         },
         {
           name: 'periodEnd',
-          valueString: measurementPeriodFormatted?.end.split('T')[0]
+          valueDate: measurementPeriodFormatted?.end.split('T')[0]
         },
         {
           name: 'reportType',
@@ -194,7 +195,7 @@ export default function PopulationCalculation() {
       body: JSON.stringify(parameters),
       headers: { 'Content-Type': 'application/json+fhir' }
     });
-    const responseBody: fhir4.Bundle | fhir4.OperationOutcome = await response.json();
+    const responseBody: fhir4.Bundle | fhir4.Parameters | fhir4.OperationOutcome = await response.json();
     if (responseBody.resourceType === 'OperationOutcome') {
       showNotification({
         icon: <IconAlertCircle />,
@@ -214,9 +215,9 @@ export default function PopulationCalculation() {
   const onEvaluate = (): void => {
     setEvaluateText(''); // clear text until evaluation is done
     sendEvaluate()
-      .then(responseBundle => {
-        if (responseBundle) {
-          setEvaluateText(JSON.stringify(responseBundle, null, 2));
+      .then(response => {
+        if (response) {
+          setEvaluateText(JSON.stringify(response, null, 2));
         }
       })
       .catch(e => {

--- a/components/calculation/PopulationCalculation.tsx
+++ b/components/calculation/PopulationCalculation.tsx
@@ -1,4 +1,17 @@
-import { Button, Center, Drawer, Grid, Group, Modal, Radio, Select, Space, Text, Tooltip } from '@mantine/core';
+import {
+  Button,
+  Center,
+  CopyButton,
+  Drawer,
+  Grid,
+  Group,
+  Modal,
+  Radio,
+  Select,
+  Space,
+  Text,
+  Tooltip
+} from '@mantine/core';
 import CodeMirror from '@uiw/react-codemirror';
 import { useRecoilValue } from 'recoil';
 import { Calculator, CalculatorTypes } from 'fqm-execution';
@@ -7,7 +20,7 @@ import { measureBundleState } from '../../state/atoms/measureBundle';
 import { useState } from 'react';
 import { measurementPeriodFormattedState } from '../../state/atoms/measurementPeriod';
 import { showNotification } from '@mantine/notifications';
-import { IconAlertCircle, IconCircleCheck } from '@tabler/icons';
+import { IconAlertCircle, IconCircleCheck, IconCopy } from '@tabler/icons';
 import { getPatientInfoString, getPatientNameString } from '../../util/fhir/patient';
 import { createDataExchangeMeasureReport, createPatientBundle } from '../../util/fhir/resourceCreation';
 import PopulationResultTable, { LabeledDetailedResult } from './PopulationResultsTable';
@@ -124,8 +137,6 @@ export default function PopulationCalculation() {
               return { value: idObj.postedId, label: getPatientNameString(idObj.testCaseInfo.patient) };
             })
           );
-
-          // TODO: fix this to have better labels
           setEnableEvaluateButton(true);
         } else {
           showNotification({
@@ -199,6 +210,7 @@ export default function PopulationCalculation() {
    * Wrapper function that calls sendEvaluate() and populates the results view
    */
   const onEvaluate = (): void => {
+    setEvaluateText(''); // clear text until evaluation is done
     sendEvaluate()
       .then(responseBundle => {
         if (responseBundle) {
@@ -438,6 +450,7 @@ export default function PopulationCalculation() {
                     value={subjectValue}
                     onChange={setSubjectValue}
                     disabled={reportTypeValue === 'population'}
+                    searchable={true}
                   />
                 </Center>
               </Grid.Col>
@@ -453,11 +466,18 @@ export default function PopulationCalculation() {
                 </Center>
               </Grid.Col>
               <Grid.Col>
+                <CopyButton value={evaluateText}>
+                  {({ copied, copy }) => (
+                    <Button color={copied ? 'teal' : 'blue'} onClick={copy}>
+                      <IconCopy />
+                    </Button>
+                  )}
+                </CopyButton>
                 <Text lineClamp={4}>
                   <CodeMirror
                     data-autofocus
                     data-testid="codemirror"
-                    height="200px"
+                    height="300px"
                     value={evaluateText}
                     theme="light"
                     editable={false}


### PR DESCRIPTION
# Summary
Modal that gives options and results of sending an evaluate request to the evaluation service.

Probably not a perfect UI/UX but hopefully good enough for now.

## New Behavior
Evaluate button pops a modal that gives options for report type and if subject type, also gives options to select a subject. When the user selects "Evaluate", the application sends an $evaluate request to the evaluation service with the selected parameters.

## Code Changes

- All changes are in the PopulationCalculation component. Adds evaluation functions and Modal component pieces.

# Testing Guidance

- `npm run check`
- `npm run dev`
- Load a measure that's currently on the evaluation service, or you can use the measure repository service (https://flame-demo.c3ib.org/mrs/4_0_1) to select. Suggest using measure 506 if testing with bellese server. Note: some small changes are required to work with the bellese server, which can be found on the branch here: https://github.com/projecttacoma/fqm-testify/tree/bellese-compatible
- Enter the evaluation service url (https://connectathon.fhir-sandbox.bellese.dev/fhir or deqm-test-server base). Click verify. Click next.
- Load patients for testing. For measure 506, recommend test patients from https://github.com/cqframework/ecqm-content-cms-2025/tree/master/bundles/measure/CMS506FHIRSafeUseofOpioids/CMS506FHIRSafeUseofOpioids-files
- Select Submit Data button, once successful, select Evaluate button
- Choose evaluation parameters and hit "Evaluate". Recommend subject-level evaluation, especially with bellese server to reduce timeout, but population level should work as well (may take a while).
- Compare the received measure report calculated populations with the populations in fqm-testify for that patient.