### PR TITLE
Subject group

### DIFF
--- a/components/calculation/PopulationCalculation.tsx
+++ b/components/calculation/PopulationCalculation.tsx
@@ -239,7 +239,7 @@ export default function PopulationCalculation() {
         }
       ]
     };
-    if (reportTypeValue === 'subject' && subjectValue) {
+    if (subjectValue) {
       if (subjectValue === 'All') {
         const groupId = uuidv4();
         parameters.parameter?.push({
@@ -547,8 +547,8 @@ export default function PopulationCalculation() {
                     data={subjectData}
                     value={subjectValue}
                     onChange={setSubjectValue}
-                    disabled={reportTypeValue === 'population'}
                     searchable={true}
+                    clearable
                   />
                 </Center>
               </Grid.Col>

--- a/components/calculation/PopulationCalculation.tsx
+++ b/components/calculation/PopulationCalculation.tsx
@@ -40,6 +40,7 @@ import { useDisclosure } from '@mantine/hooks';
 import { evaluationState } from '../../state/atoms/evaluation';
 import { dataRequirementsLookupByType } from '../../state/selectors/dataRequirementsLookupByType';
 import { minimizeTestCaseResources } from '../../util/ValueSetHelper';
+import { v4 as uuidv4 } from 'uuid';
 
 export default function PopulationCalculation() {
   const router = useRouter();
@@ -240,10 +241,12 @@ export default function PopulationCalculation() {
     };
     if (reportTypeValue === 'subject' && subjectValue) {
       if (subjectValue === 'All') {
+        const groupId = uuidv4();
         parameters.parameter?.push({
           name: 'subjectGroup',
           resource: {
             resourceType: 'Group',
+            id: groupId,
             type: 'person',
             actual: true,
             member: subjectData.slice(1).map(subjectInfo => {
@@ -254,6 +257,10 @@ export default function PopulationCalculation() {
               };
             })
           }
+        });
+        parameters.parameter?.push({
+          name: 'subject',
+          valueString: `Group/${groupId}`
         });
       } else {
         parameters.parameter?.push({


### PR DESCRIPTION
# Summary
Adds an "All" option to the evaluate subject list which is implemented using the subjectGroup parameter.

## New Behavior
When the user selects the All subject option, they should be able to see subjectGroup results where the subjectGroup is created with all loaded test cases. Additionally, the user may do either population or subject reportType evaluation with an optional subject chosen from the dropdown.

## Code Changes
All code changes are in `PopulationCalculation.tsx` which expands the subject dropdown to include the "All" option and adds subject parameters appropriately when calling the server $evaluate operation. Changes in the Select component no longer disable the subject dropdown for population reporting and also allow the subject to be cleared (for a full server option).

# Testing Guidance
- `npm run check`
- `PORT=3001 npm run dev`
- Pull the deqm-test-server branch here if not yet merged https://github.com/projecttacoma/deqm-test-server/pull/170
- Load the CMS connectathon measures (recommended to have better data to work with than the 2021 measures)...
- `npm run db:reset`
- `npm run upload-bundles [bundles path]` (ecqm-content-cms-2025)
- Start the deqm-test-server local instance (`npm run start`)
- In fqm-testify, load a measure that is in the deqm-test-server instance (I used CMS506)
- Use http://localhost:3000/4_0_1 for the Evaluation Service URL and click "Verify" then "Next"
- Load some test cases (recommend partial to be able to easily compare with full server evaluate)
- Choose the "Submit Data" dropdown from the bottom left (either option should be fine)
- Choose the "Evaluate" button
- Experiment with the population report type combined with the "All" subject (which creates a subjectGroup for all of the loaded patients)
- Make sure other population report type options still work
- You can also experiment with the subject report type, but the subjectGroup "All" option for subject report type is not yet implemented on the server

If updated, also consider testing with the flame-demo server